### PR TITLE
Use correct path for script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - attach_workspace:
           at: /go/src/github.com/palantir/bulldozer
       - *build-docker-image
-      - run: ./publish-docker.sh
+      - run: ./scripts/publish-docker.sh
 
 workflows:
   version: 2


### PR DESCRIPTION
Looks like the workspace persist worked, but the build failed to call the right script.