### PR TITLE
Cap body limit to 6M

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -42,6 +42,7 @@ func New(db *sqlx.DB, startup *config.Startup) *Server {
 	e := echo.New()
 
 	e.Use(bm.ContextMiddleware)
+	e.Use(middleware.BodyLimit("6M"))
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Format: config.EchoLoggingFormat,
 		Skipper: func(c echo.Context) bool {


### PR DESCRIPTION
We should limit the body limit per GitHub payload specs (https://developer.github.com/webhooks/#payloads).