### PR TITLE
Include commit title when merging PR

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -348,6 +348,7 @@ func (client *Client) Merge(pr *github.PullRequest) error {
 		commitMessage,
 		&github.PullRequestOptions{
 			MergeMethod: mergeMethod,
+			CommitTitle: pr.GetTitle(),
 		})
 	if err != nil {
 		return errors.Wrapf(err, "merge of %s-%d has failed", repo.GetFullName(), pr.GetNumber())


### PR DESCRIPTION
Current logic uses the first commit as the PR title which is often misleading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/40)
<!-- Reviewable:end -->
