### PR TITLE
Add support for multiple config file paths

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -54,6 +54,7 @@ const (
 
 var (
 	AcceptedPermLevels = []string{"write", "admin"}
+	DefaultConfigPaths = []string{".bulldozer.yml"}
 )
 
 type UpdateStrategy string
@@ -68,11 +69,21 @@ const (
 	UpdateStrategyAlways UpdateStrategy = "always"
 )
 
+type Option func(c *Client)
+
+func WithConfigPaths(paths []string) Option {
+	return func(c *Client) {
+		c.configPaths = paths
+	}
+}
+
 type Client struct {
 	Logger *logrus.Entry
 	Ctx    context.Context
 
 	*github.Client
+
+	configPaths []string
 }
 
 type BulldozerFile struct {
@@ -82,21 +93,35 @@ type BulldozerFile struct {
 	UpdateStrategy   UpdateStrategy `yaml:"updateStrategy"`
 }
 
-func FromToken(c echo.Context, token string) *Client {
+func FromToken(c echo.Context, token string, opts ...Option) *Client {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	tc := oauth2.NewClient(context.TODO(), ts)
 
-	client := github.NewClient(tc)
+	gh := github.NewClient(tc)
 
-	client.BaseURL, _ = url.Parse(config.Instance.Github.APIURL)
-	client.UserAgent = "bulldozer/" + version.Version()
+	gh.BaseURL, _ = url.Parse(config.Instance.Github.APIURL)
+	gh.UserAgent = "bulldozer/" + version.Version()
 
-	return &Client{log.FromContext(c), context.TODO(), client}
+	client := &Client{
+		Logger: log.FromContext(c),
+		Ctx:    context.TODO(),
+		Client: gh,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	if len(client.configPaths) == 0 {
+		client.configPaths = DefaultConfigPaths
+	}
+
+	return client
 }
 
-func FromAuthHeader(c echo.Context, authHeader string) (*Client, error) {
+func FromAuthHeader(c echo.Context, authHeader string, opts ...Option) (*Client, error) {
 	if authHeader == "" {
 		return nil, errors.New("authorization header not present")
 	}
@@ -107,18 +132,13 @@ func FromAuthHeader(c echo.Context, authHeader string) (*Client, error) {
 	}
 
 	token := parts[1]
-	return FromToken(c, token), nil
+	return FromToken(c, token, opts...), nil
 }
 
 func (client *Client) ConfigFile(repo *github.Repository, ref string) (*BulldozerFile, error) {
-	owner := repo.Owner.GetLogin()
-	name := repo.GetName()
-
-	repositoryContent, _, _, err := client.Repositories.GetContents(client.Ctx, owner, name, ".bulldozer.yml", &github.RepositoryContentGetOptions{
-		Ref: ref,
-	})
+	repositoryContent, err := client.findConfigFile(repo, ref)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot get .bulldozer.yml for %s on ref %s", repo.GetFullName(), ref)
+		return nil, err
 	}
 
 	content, err := repositoryContent.GetContent()
@@ -151,6 +171,28 @@ func (client *Client) ConfigFile(repo *github.Repository, ref string) (*Bulldoze
 	}
 
 	return &bulldozerFile, nil
+}
+
+func (client *Client) findConfigFile(repo *github.Repository, ref string) (*github.RepositoryContent, error) {
+	owner := repo.Owner.GetLogin()
+	name := repo.GetName()
+
+	opts := github.RepositoryContentGetOptions{
+		Ref: ref,
+	}
+
+	for _, p := range client.configPaths {
+		content, _, _, err := client.Repositories.GetContents(client.Ctx, owner, name, p, &opts)
+		if err != nil {
+			if rerr, ok := err.(*github.ErrorResponse); ok && rerr.Response.StatusCode == http.StatusNotFound {
+				continue
+			}
+			return nil, errors.Wrapf(err, "cannot get %s for %s on ref %s", p, repo.GetFullName(), ref)
+		}
+		return content, nil
+	}
+
+	return nil, errors.Errorf("no configuration found for %s on ref %s", repo.GetFullName(), ref)
 }
 
 func (client *Client) MergeMethod(branch *github.PullRequestBranch) (string, error) {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -39,11 +39,12 @@ var (
 )
 
 type Startup struct {
-	Server   Rest            `yaml:"rest" validate:"required"`
-	Logging  LoggingConfig   `yaml:"logging" validate:"required,dive"`
-	Database *DatabaseConfig `yaml:"database" validate:"required,dive"`
-	Github   *GithubConfig   `yaml:"github" validate:"required,dive"`
-	AssetDir string          `yaml:"assetDir" validate:"required"`
+	Server      Rest            `yaml:"rest" validate:"required"`
+	Logging     LoggingConfig   `yaml:"logging" validate:"required,dive"`
+	Database    *DatabaseConfig `yaml:"database" validate:"required,dive"`
+	Github      *GithubConfig   `yaml:"github" validate:"required,dive"`
+	AssetDir    string          `yaml:"assetDir" validate:"required"`
+	ConfigPaths []string        `yaml:"configPaths"`
 }
 
 type Rest struct {

--- a/server/endpoints/hook.go
+++ b/server/endpoints/hook.go
@@ -31,7 +31,7 @@ import (
 	"github.com/palantir/bulldozer/server/config"
 )
 
-func Hook(db *sqlx.DB, secret string) echo.HandlerFunc {
+func Hook(db *sqlx.DB, secret string, configPaths []string) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		logger := log.FromContext(c)
 
@@ -56,7 +56,7 @@ func Hook(db *sqlx.DB, secret string) echo.HandlerFunc {
 			return errors.Wrapf(err, "cannot get user %s from database", dbRepo.EnabledBy)
 		}
 
-		ghClient := gh.FromToken(c, user.Token)
+		ghClient := gh.FromToken(c, user.Token, gh.WithConfigPaths(configPaths))
 
 		if !(result.Update || result.Merge) {
 			return c.String(http.StatusOK, "Not taking action")

--- a/server/server.go
+++ b/server/server.go
@@ -74,7 +74,7 @@ func registerEndpoints(startup *config.Startup, e *echo.Echo, db *sqlx.DB) {
 	e.POST("/api/repo/:owner/:name", endpoints.RepositoryEnable(db, startup.Github.WebHookURL, startup.Github.WebhookSecret))
 	e.DELETE("/api/repo/:owner/:name", endpoints.RepositoryDisable(db))
 
-	e.POST("/api/github/hook", endpoints.Hook(db, startup.Github.WebhookSecret))
+	e.POST("/api/github/hook", endpoints.Hook(db, startup.Github.WebhookSecret, startup.ConfigPaths))
 	e.GET("/api/auth/github/token", endpoints.Token(db))
 }
 


### PR DESCRIPTION
Based on server configuration, the application will now look for the
repository configuration file in multiple paths until it finds one. If
no paths are specified, the existing .bulldozer.yml is used.

This commit makes the minimal amount of change necessary to get this
working. Ideally, there would be more refactoring to standardize config
passing and client construction, but I'm not ready to do that yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/44)
<!-- Reviewable:end -->
