### PR TITLE
Allow whitespace when finding commit messages

### DIFF
--- a/github/github_test.go
+++ b/github/github_test.go
@@ -771,3 +771,26 @@ func TestSquashCommitMessage(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "", commitMessage)
 }
+
+func TestExtractMessageOverride(t *testing.T) {
+	_, ok := extractMessageOverride("no override here")
+	assert.False(t, ok, "found unexpected message override")
+
+	_, ok = extractMessageOverride("==COMITT_MSG==\r\nUnclosed message")
+	assert.False(t, ok, "found unexpected message override")
+
+	msg, ok := extractMessageOverride("==COMMIT_MSG==\r\nThe real message\r\n==COMMIT_MSG==")
+	if assert.True(t, ok, "override was not found") {
+		assert.Equal(t, "The real message", msg)
+	}
+
+	msg, ok = extractMessageOverride("==COMMIT_MSG== \r\nThe real message\r\n  ==COMMIT_MSG==")
+	if assert.True(t, ok, "override was not found") {
+		assert.Equal(t, "The real message", msg)
+	}
+
+	msg, ok = extractMessageOverride("==SQUASH_MSG==\nThe real message\n==SQUASH_MSG==")
+	if assert.True(t, ok, "override was not found") {
+		assert.Equal(t, "The real message", msg)
+	}
+}


### PR DESCRIPTION
Allow whitespace after the opening tag and before the closing tag that
delimit commit messages in a PR body. Also place the regexp in
multi-line mode and use `^` and `$` to match the start and end of lines
instead of the literal `\r\n` string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/47)
<!-- Reviewable:end -->
