### PR TITLE
Add dist configuration for Godel

### DIFF
--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -4,8 +4,6 @@ product-defaults:
 
 products:
   bulldozer:
-    dist:
-      output-dir: build
     build:
       output-dir: build
       main-pkg: .
@@ -15,6 +13,11 @@ products:
       os-archs:
       - os: linux
         arch: amd64
+    dist:
+      output-dir: build
+      disters:
+        bin:
+          type: bin
     docker:
       docker-builders:
         bulldozer:


### PR DESCRIPTION
This is required for Bintray uploads to work. Since there's only a
single binary, os-arch-bin might be more appropriate, but this matches
policy-bot for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/54)
<!-- Reviewable:end -->
