### PR TITLE
Close pull requests after merge

### DIFF
--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -122,6 +122,15 @@ func MergePR(ctx context.Context, pullCtx pull.Context, client *github.Client, m
 
 			logger.Info().Msgf("Successfully merged pull request for sha %s with message %q", result.GetSHA(), result.GetMessage())
 
+			// Due to an issue with GitHub, pull requests are not always closed
+			// after merging, see issue #52 for more details.
+			if _, _, err := client.PullRequests.Edit(ctx, pullCtx.Owner(), pullCtx.Repo(), pullCtx.Number(), &github.PullRequest{
+				State: github.String("closed"),
+			}); err != nil {
+				logger.Error().Err(errors.WithStack(err)).Msgf("Failed to close PR after merge")
+				return
+			}
+
 			// Delete ref if owner of BASE and HEAD match
 			// otherwise, its from a fork that we cannot delete
 			if pr.GetBase().GetUser().GetLogin() == pr.GetHead().GetUser().GetLogin() {


### PR DESCRIPTION
This should happen automatically, but doesn't always. For now,
explicitly set the PR state to closed after a successful merge.

Fixes #52.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/55)
<!-- Reviewable:end -->
