### PR TITLE
Remove close PR calls, update required permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ bulldozer requires the following permissions as a GitHub app:
 * Repository Contents - read & write
 * Issues - read-only
 * Repository metadata - read-only
-* Pull requests - read-only
+* Pull requests - read & write
 * Commit status - read-only
 
 It should be subscribed to the following events:

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -122,15 +122,6 @@ func MergePR(ctx context.Context, pullCtx pull.Context, client *github.Client, m
 
 			logger.Info().Msgf("Successfully merged pull request for sha %s with message %q", result.GetSHA(), result.GetMessage())
 
-			// Due to an issue with GitHub, pull requests are not always closed
-			// after merging, see issue #52 for more details.
-			if _, _, err := client.PullRequests.Edit(ctx, pullCtx.Owner(), pullCtx.Repo(), pullCtx.Number(), &github.PullRequest{
-				State: github.String("closed"),
-			}); err != nil {
-				logger.Error().Err(errors.WithStack(err)).Msgf("Failed to close PR after merge")
-				return
-			}
-
 			// Delete ref if owner of BASE and HEAD match
 			// otherwise, its from a fork that we cannot delete
 			if pr.GetBase().GetUser().GetLogin() == pr.GetHead().GetUser().GetLogin() {


### PR DESCRIPTION
GitHub does close PRs, but the app has to have the correct permissions.
While write on the repo contents is needed for merging, write on PRs
seems to be needed for closing them.

This reverts commit 25d3ff129b605185c51de03b7b3f4f8c7d65711f.

This _really_ fixes #52.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/56)
<!-- Reviewable:end -->
