### PR TITLE
Assert version 1 configuration

### DIFF
--- a/bulldozer/config_fetcher.go
+++ b/bulldozer/config_fetcher.go
@@ -146,6 +146,10 @@ func (cf *ConfigFetcher) unmarshalConfig(bytes []byte) (*Config, error) {
 		return nil, errors.Wrapf(err, "failed to unmarshal configuration")
 	}
 
+	if config.Version != 1 {
+		return nil, errors.Errorf("unexpected version '%d', expected 1", config.Version)
+	}
+
 	return &config, nil
 }
 


### PR DESCRIPTION
While `UnmarshalStrict` does mean that we don't unmarshal a v0 config at the same path as v1, we currently don't assert that the v1 configuration actually matches version == 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/57)
<!-- Reviewable:end -->
