### PR TITLE
ignore case when evaluating labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ merge:
   # "whitelist" defines how to select PRs to evaluate and merge
   whitelist:
 
-    # "labels" is a list of labels that must be matched to whitelist a PR for merging
+    # "labels" is a list of labels that must be matched to whitelist a PR for merging (case-insensitive)
     labels: ["merge when ready"]
 
     # "comment_substrings" matches on substrings in comments
@@ -39,7 +39,7 @@ merge:
   # "blacklist" defines how to exclude PRs from evaluation and merging
   blacklist:
 
-    # similar as above, "labels" defines a list of labels. In this case, matched labels cause exclusion.
+    # similar as above, "labels" defines a list of labels. In this case, matched labels cause exclusion. (case-insensitive)
     labels: ["do not merge"]
 
     # "comment_substrings" matches substrings in comments. In this case, matched substrings cause exclusion.

--- a/bulldozer/config_fetcher.go
+++ b/bulldozer/config_fetcher.go
@@ -166,12 +166,12 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 			Version: 1,
 			Update: UpdateConfig{
 				Whitelist: Signals{
-					Labels: []string{"update me", "Update Me", "UPDATE ME", "update-me", "Update-Me", "UPDATE-ME", "update_me", "Update_Me", "UPDATE_ME"},
+					Labels: []string{"update me", "update-me", "update_me"},
 				},
 			},
 			Merge: MergeConfig{
 				Whitelist: Signals{
-					Labels: []string{"merge when ready", "Merge When Ready", "MERGE WHEN READY", "merge-when-ready", "Merge-When-Ready", "MERGE-WHEN-READY", "merge_when_ready", "Merge_When_Ready", "MERGE_WHEN_READY"},
+					Labels: []string{"merge when ready", "merge-when-ready", "merge_when_ready"},
 				},
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
@@ -185,12 +185,12 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 			Version: 1,
 			Update: UpdateConfig{
 				Whitelist: Signals{
-					Labels: []string{"update me", "Update Me", "UPDATE ME", "update-me", "Update-Me", "UPDATE-ME", "update_me", "Update_Me", "UPDATE_ME"},
+					Labels: []string{"update me", "update-me", "update_me"},
 				},
 			},
 			Merge: MergeConfig{
 				Blacklist: Signals{
-					Labels: []string{"do not merge", "Do Not Merge", "DO NOT MERGE", "wip", "WIP", "do-not-merge", "Do-Not-Merge", "DO-NOT-MERGE", "do_not_merge", "Do_Not_Merge", "DO_NOT_MERGE"},
+					Labels: []string{"wip", "do not merge", "do-not-merge", "do_not_merge"},
 				},
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
@@ -204,7 +204,7 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 			Version: 1,
 			Update: UpdateConfig{
 				Whitelist: Signals{
-					Labels: []string{"update me", "Update Me", "UPDATE ME", "update-me", "Update-Me", "UPDATE-ME", "update_me", "Update_Me", "UPDATE_ME"},
+					Labels: []string{"update me", "update-me", "update_me"},
 				},
 			},
 			Merge: MergeConfig{

--- a/bulldozer/evaluate.go
+++ b/bulldozer/evaluate.go
@@ -33,7 +33,7 @@ func IsPRBlacklisted(ctx context.Context, pullCtx pull.Context, config Signals) 
 		return true, "unable to list PR labels", err
 	}
 
-	if inSlice, idx := anyInSlice(labels, config.Labels); inSlice {
+	if inSlice, idx := anyInSliceCaseInsensitive(labels, config.Labels); inSlice {
 		return true, fmt.Sprintf("PR label matches one of specified blacklist labels: %q", config.Labels[idx]), nil
 	}
 
@@ -80,7 +80,7 @@ func IsPRWhitelisted(ctx context.Context, pullCtx pull.Context, config Signals) 
 		return false, "unable to list PR labels", err
 	}
 
-	if inSlice, idx := anyInSlice(labels, config.Labels); inSlice {
+	if inSlice, idx := anyInSliceCaseInsensitive(labels, config.Labels); inSlice {
 		return true, fmt.Sprintf("PR label matches one of specified whitelist labels: %q", config.Labels[idx]), nil
 	}
 
@@ -127,6 +127,18 @@ func anyInSlice(testValues []string, elements []string) (bool, int) {
 			}
 		}
 	}
+	return false, -1
+}
+
+func anyInSliceCaseInsensitive(testValues []string, elements []string) (bool, int) {
+	for _, testValue := range testValues {
+		for index, element := range elements {
+			if strings.EqualFold(testValue, element) {
+				return true, index
+			}
+		}
+	}
+
 	return false, -1
 }
 

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -135,7 +135,7 @@ func TestSimpleXListed(t *testing.T) {
 		assert.Equal(t, "PR label matches one of specified blacklist labels: \"LABEL_NOMERGE\"", actualBlacklistReason)
 	})
 
-	t.Run("labelCausesBlacklist case-insensitive", func(t *testing.T) {
+	t.Run("labelCausesBlacklistCaseInsensitive", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			LabelValue: []string{"LABEL_nomERGE"},
 		}
@@ -157,7 +157,7 @@ func TestSimpleXListed(t *testing.T) {
 		assert.Equal(t, "PR label matches one of specified whitelist labels: \"LABEL_MERGE\"", actualWhitelistReason)
 	})
 
-	t.Run("labelCausesWhitelist case-insensitive", func(t *testing.T) {
+	t.Run("labelCausesWhitelistCaseInsensitive", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			LabelValue: []string{"LABEL_meRGE"},
 		}
@@ -218,7 +218,7 @@ func TestShouldMerge(t *testing.T) {
 		assert.True(t, actualShouldMerge)
 	})
 
-	t.Run("labelShouldMerge - case insensitive", func(t *testing.T) {
+	t.Run("labelShouldMergeCaseInsensitive", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			LabelValue: []string{"LABEL_merGE"},
 		}
@@ -273,7 +273,7 @@ func TestShouldMerge(t *testing.T) {
 		assert.False(t, actualShouldMerge)
 	})
 
-	t.Run("labelCausesBlacklist - case insensitive", func(t *testing.T) {
+	t.Run("labelCausesBlacklistCaseInsensitive", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			LabelValue: []string{"LABEL_nomERGE"},
 		}

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -218,6 +218,17 @@ func TestShouldMerge(t *testing.T) {
 		assert.True(t, actualShouldMerge)
 	})
 
+	t.Run("labelShouldMerge - case insensitive", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			LabelValue: []string{"LABEL_merGE"},
+		}
+
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+
+		require.Nil(t, err)
+		assert.True(t, actualShouldMerge)
+	})
+
 	t.Run("noContextShouldntMerge", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			LabelValue:   []string{"NOT_A_LABEL"},
@@ -254,6 +265,17 @@ func TestShouldMerge(t *testing.T) {
 	t.Run("labelCausesBlacklist", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			LabelValue: []string{"LABEL_NOMERGE"},
+		}
+
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+
+		require.Nil(t, err)
+		assert.False(t, actualShouldMerge)
+	})
+
+	t.Run("labelCausesBlacklist - case insensitive", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			LabelValue: []string{"LABEL_nomERGE"},
 		}
 
 		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -143,7 +143,7 @@ func TestSimpleXListed(t *testing.T) {
 		actualBlacklist, actualBlacklistReason, err := IsPRBlacklisted(ctx, pc, mergeConfig.Blacklist)
 		require.Nil(t, err)
 		assert.True(t, actualBlacklist)
-		assert.Equal(t, "PR label matches one of specified blacklist labels: \"LABEL_nomERGE\"", actualBlacklistReason)
+		assert.Equal(t, "PR label matches one of specified blacklist labels: \"LABEL_NOMERGE\"", actualBlacklistReason)
 	})
 
 	t.Run("labelCausesWhitelist", func(t *testing.T) {
@@ -159,13 +159,13 @@ func TestSimpleXListed(t *testing.T) {
 
 	t.Run("labelCausesWhitelist case-insensitive", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
-			LabelValue: []string{"LABEL_merRGE"},
+			LabelValue: []string{"LABEL_meRGE"},
 		}
 
 		actualWhitelist, actualWhitelistReason, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
 		require.Nil(t, err)
 		assert.True(t, actualWhitelist)
-		assert.Equal(t, "PR label matches one of specified whitelist labels: \"LABEL_merRGE\"", actualWhitelistReason)
+		assert.Equal(t, "PR label matches one of specified whitelist labels: \"LABEL_MERGE\"", actualWhitelistReason)
 	})
 }
 

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -133,13 +133,18 @@ func TestSimpleXListed(t *testing.T) {
 		require.Nil(t, err)
 		assert.True(t, actualBlacklist)
 		assert.Equal(t, "PR label matches one of specified blacklist labels: \"LABEL_NOMERGE\"", actualBlacklistReason)
+	})
+
+	t.Run("labelCausesWhitelist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			LabelValue: []string{"LABEL_MERGE"},
+		}
 
 		actualWhitelist, actualWhitelistReason, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
 		require.Nil(t, err)
-		assert.False(t, actualWhitelist)
-		assert.Equal(t, "no matching whitelist found", actualWhitelistReason)
+		assert.True(t, actualWhitelist)
+		assert.Equal(t, "PR label matches one of specified whitelist labels: \"LABEL_MERGE\"", actualWhitelistReason)
 	})
-
 }
 
 func TestShouldMerge(t *testing.T) {

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -135,6 +135,17 @@ func TestSimpleXListed(t *testing.T) {
 		assert.Equal(t, "PR label matches one of specified blacklist labels: \"LABEL_NOMERGE\"", actualBlacklistReason)
 	})
 
+	t.Run("labelCausesBlacklist case-insensitive", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			LabelValue: []string{"LABEL_nomERGE"},
+		}
+
+		actualBlacklist, actualBlacklistReason, err := IsPRBlacklisted(ctx, pc, mergeConfig.Blacklist)
+		require.Nil(t, err)
+		assert.True(t, actualBlacklist)
+		assert.Equal(t, "PR label matches one of specified blacklist labels: \"LABEL_nomERGE\"", actualBlacklistReason)
+	})
+
 	t.Run("labelCausesWhitelist", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			LabelValue: []string{"LABEL_MERGE"},
@@ -144,6 +155,17 @@ func TestSimpleXListed(t *testing.T) {
 		require.Nil(t, err)
 		assert.True(t, actualWhitelist)
 		assert.Equal(t, "PR label matches one of specified whitelist labels: \"LABEL_MERGE\"", actualWhitelistReason)
+	})
+
+	t.Run("labelCausesWhitelist case-insensitive", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			LabelValue: []string{"LABEL_merRGE"},
+		}
+
+		actualWhitelist, actualWhitelistReason, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
+		require.Nil(t, err)
+		assert.True(t, actualWhitelist)
+		assert.Equal(t, "PR label matches one of specified whitelist labels: \"LABEL_merRGE\"", actualWhitelistReason)
 	})
 }
 


### PR DESCRIPTION
fixes #62

### Current Behavior
Labels and configuration must have the same case to trigger the white/black-list functionality.

### Desired Behavior
Allow the labels to be case-insensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/64)
<!-- Reviewable:end -->
