### PR TITLE
post comment for user-fixable errors

### DIFF
--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -203,7 +203,7 @@ func postCommentIfUserActionable(ctx context.Context, client *github.Client, own
 
 	switch {
 	case strings.HasPrefix(githubError.Message, "You're not authorized to push to this branch."):
-		commentBody = commentBody + "\n\nThe bulldozer bot account may not be allowed to merge to the branch."
+		commentBody = commentBody + "\n\nThe bulldozer bot account may not be allowed to merge the branch."
 
 	case githubError.Message == "Merge commits are not allowed on this repository.":
 		commentBody = commentBody + "\n\nThe bulldozer configuration for merge method may not match the repository settings."


### PR DESCRIPTION
fixes #63 

### Current Behavior
There are times where bulldozer will fail to merge a PR due to user error, specifically:

* when the merge strategy configured for bulldozer is not allowed in the repo
* when the bulldozer bot is not allowed to merge to the target branch, due to branch protections

There is no signal to the user that they can fix this issue, so they are left thinking bulldozer is broken.

### Desired Behavior
Bulldozer should post a comment in the 2 above cases, alerting the user to:

* the error returned by GitHub, since it may contain debug information, URLs, etc.
* potential solution to the problem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/65)
<!-- Reviewable:end -->
