### PR TITLE
Evaluate PR Body independently from comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ merge:
     # "comment_substrings" matches on substrings in comments
     comment_substrings: ["==MERGE_WHEN_READY=="]
 
+    # "pr_body_substrings" matches on substrings in the PR body
+    pr_body_substrings: ["==MERGE_WHEN_READY=="]
+
   # "blacklist" defines how to exclude PRs from evaluation and merging
   blacklist:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ merge:
     # "labels" is a list of labels that must be matched to whitelist a PR for merging (case-insensitive)
     labels: ["merge when ready"]
 
-    # "comment_substrings" matches on substrings in comments
+    # "comment_substrings" matches on substrings in comments or the pull request body
     comment_substrings: ["==MERGE_WHEN_READY=="]
 
     # "pr_body_substrings" matches on substrings in the PR body

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -31,6 +31,7 @@ type Signals struct {
 	Labels            []string `yaml:"labels"`
 	CommentSubstrings []string `yaml:"comment_substrings"`
 	Comments          []string `yaml:"comments"`
+	PRBodySubstrings  []string `yaml:"pr_body_substrings"`
 }
 
 func (s *Signals) Enabled() bool {

--- a/bulldozer/evaluate.go
+++ b/bulldozer/evaluate.go
@@ -51,11 +51,21 @@ func IsPRBlacklisted(ctx context.Context, pullCtx pull.Context, config Signals) 
 		return true, fmt.Sprintf("PR comment matches one of specified blacklist comments: %q", config.Comments[idx]), nil
 	}
 
+	for _, blacklistedComment := range config.Comments {
+		if blacklistedComment == body {
+			return true, fmt.Sprintf("PR body matches one of specified blacklist comments: %q", blacklistedComment), nil
+		}
+	}
+
 	for _, blacklistedSubstring := range config.CommentSubstrings {
 		for _, comment := range comments {
 			if strings.Contains(comment, blacklistedSubstring) {
 				return true, fmt.Sprintf("PR comment matches one of specified blacklist comment substrings: %q", blacklistedSubstring), nil
 			}
+		}
+
+		if strings.Contains(body, blacklistedSubstring) {
+			return true, fmt.Sprintf("PR body matches one of specified blacklist comment substrings: %q", blacklistedSubstring), nil
 		}
 	}
 
@@ -94,11 +104,21 @@ func IsPRWhitelisted(ctx context.Context, pullCtx pull.Context, config Signals) 
 		return true, fmt.Sprintf("PR comment matches one of specified whitelist comments: %q", config.Comments[idx]), nil
 	}
 
+	for _, whitelistedComment := range config.Comments {
+		if whitelistedComment == body {
+			return true, fmt.Sprintf("PR body matches one of specified whitelist comments: %q", whitelistedComment), nil
+		}
+	}
+
 	for _, whitelistedSubstring := range config.CommentSubstrings {
 		for _, comment := range comments {
 			if strings.Contains(comment, whitelistedSubstring) {
 				return true, fmt.Sprintf("PR comment matches one of specified whitelist comment substrings: %q", whitelistedSubstring), nil
 			}
+		}
+
+		if strings.Contains(body, whitelistedSubstring) {
+			return true, fmt.Sprintf("PR body matches one of specified whitelist comment substrings: %q", whitelistedSubstring), nil
 		}
 	}
 

--- a/bulldozer/evaluate.go
+++ b/bulldozer/evaluate.go
@@ -51,21 +51,17 @@ func IsPRBlacklisted(ctx context.Context, pullCtx pull.Context, config Signals) 
 		return true, fmt.Sprintf("PR comment matches one of specified blacklist comments: %q", config.Comments[idx]), nil
 	}
 
-	for _, blacklistedComment := range config.Comments {
-		if blacklistedComment == body {
-			return true, fmt.Sprintf("PR body matches one of specified blacklist comments: %q", blacklistedComment), nil
-		}
-	}
-
 	for _, blacklistedSubstring := range config.CommentSubstrings {
 		for _, comment := range comments {
 			if strings.Contains(comment, blacklistedSubstring) {
 				return true, fmt.Sprintf("PR comment matches one of specified blacklist comment substrings: %q", blacklistedSubstring), nil
 			}
 		}
+	}
 
+	for _, blacklistedSubstring := range config.PRBodySubstrings {
 		if strings.Contains(body, blacklistedSubstring) {
-			return true, fmt.Sprintf("PR body matches one of specified blacklist comment substrings: %q", blacklistedSubstring), nil
+			return true, fmt.Sprintf("PR body matches one of specified blacklist substrings: %q", blacklistedSubstring), nil
 		}
 	}
 
@@ -98,21 +94,17 @@ func IsPRWhitelisted(ctx context.Context, pullCtx pull.Context, config Signals) 
 		return true, fmt.Sprintf("PR comment matches one of specified whitelist comments: %q", config.Comments[idx]), nil
 	}
 
-	for _, whitelistedComment := range config.Comments {
-		if whitelistedComment == body {
-			return true, fmt.Sprintf("PR body matches one of specified whitelist comments: %q", whitelistedComment), nil
-		}
-	}
-
 	for _, whitelistedSubstring := range config.CommentSubstrings {
 		for _, comment := range comments {
 			if strings.Contains(comment, whitelistedSubstring) {
 				return true, fmt.Sprintf("PR comment matches one of specified whitelist comment substrings: %q", whitelistedSubstring), nil
 			}
 		}
+	}
 
+	for _, whitelistedSubstring := range config.PRBodySubstrings {
 		if strings.Contains(body, whitelistedSubstring) {
-			return true, fmt.Sprintf("PR body matches one of specified whitelist comment substrings: %q", whitelistedSubstring), nil
+			return true, fmt.Sprintf("PR body matches one of specified whitelist substrings: %q", whitelistedSubstring), nil
 		}
 	}
 

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -181,6 +181,28 @@ func TestSimpleXListed(t *testing.T) {
 		assert.Equal(t, "PR body matches one of specified whitelist substrings: \"BODY_MERGE_PLZ\"", actualWhitelistReason)
 	})
 
+	t.Run("bodyCausesCommentSubstringWhitelist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue: "My PR Body\n\n\n :+1:",
+		}
+
+		actualWhitelist, actualWhitelistReason, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
+		require.Nil(t, err)
+		assert.True(t, actualWhitelist)
+		assert.Equal(t, "PR body matches one of specified whitelist comment substrings: \":+1:\"", actualWhitelistReason)
+	})
+
+	t.Run("bodyCausesCommentWhitelist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue: "FULL_COMMENT_PLZ_MERGE",
+		}
+
+		actualWhitelist, actualWhitelistReason, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
+		require.Nil(t, err)
+		assert.True(t, actualWhitelist)
+		assert.Equal(t, "PR body matches one of specified whitelist comments: \"FULL_COMMENT_PLZ_MERGE\"", actualWhitelistReason)
+	})
+
 	t.Run("bodyCausesBlacklist", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			BodyValue: "My PR Body\n\n\n BODY_NOMERGE",
@@ -190,6 +212,28 @@ func TestSimpleXListed(t *testing.T) {
 		require.Nil(t, err)
 		assert.True(t, actualBlacklist)
 		assert.Equal(t, "PR body matches one of specified blacklist substrings: \"BODY_NOMERGE\"", actualBlacklistReason)
+	})
+
+	t.Run("bodyCausesCommentSubstringBlacklist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue: "My PR Body\n\n\n :-1:",
+		}
+
+		actualBlacklist, actualBlacklistReason, err := IsPRBlacklisted(ctx, pc, mergeConfig.Blacklist)
+		require.Nil(t, err)
+		assert.True(t, actualBlacklist)
+		assert.Equal(t, "PR body matches one of specified blacklist comment substrings: \":-1:\"", actualBlacklistReason)
+	})
+
+	t.Run("bodyCausesCommentBlacklist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue: "NO_WAY",
+		}
+
+		actualBlacklist, actualBlacklistReason, err := IsPRBlacklisted(ctx, pc, mergeConfig.Blacklist)
+		require.Nil(t, err)
+		assert.True(t, actualBlacklist)
+		assert.Equal(t, "PR body matches one of specified blacklist comments: \"NO_WAY\"", actualBlacklistReason)
 	})
 
 	t.Run("errBodyFailsClosedBlacklist", func(t *testing.T) {

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -31,11 +31,13 @@ func TestSimpleXListed(t *testing.T) {
 			Labels:            []string{"LABEL_MERGE"},
 			Comments:          []string{"FULL_COMMENT_PLZ_MERGE"},
 			CommentSubstrings: []string{":+1:"},
+			PRBodySubstrings:  []string{"BODY_MERGE_PLZ"},
 		},
 		Blacklist: Signals{
 			Labels:            []string{"LABEL_NOMERGE"},
 			Comments:          []string{"NO_WAY"},
 			CommentSubstrings: []string{":-1:"},
+			PRBodySubstrings:  []string{"BODY_NOMERGE"},
 		},
 	}
 
@@ -166,6 +168,70 @@ func TestSimpleXListed(t *testing.T) {
 		require.Nil(t, err)
 		assert.True(t, actualWhitelist)
 		assert.Equal(t, "PR label matches one of specified whitelist labels: \"LABEL_MERGE\"", actualWhitelistReason)
+	})
+
+	t.Run("bodyCausesWhitelist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue: "My PR Body\n\n\n BODY_MERGE_PLZ",
+		}
+
+		actualWhitelist, actualWhitelistReason, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
+		require.Nil(t, err)
+		assert.True(t, actualWhitelist)
+		assert.Equal(t, "PR body matches one of specified whitelist substrings: \"BODY_MERGE_PLZ\"", actualWhitelistReason)
+	})
+
+	t.Run("bodyCausesBlacklist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue: "My PR Body\n\n\n BODY_NOMERGE",
+		}
+
+		actualBlacklist, actualBlacklistReason, err := IsPRBlacklisted(ctx, pc, mergeConfig.Blacklist)
+		require.Nil(t, err)
+		assert.True(t, actualBlacklist)
+		assert.Equal(t, "PR body matches one of specified blacklist substrings: \"BODY_NOMERGE\"", actualBlacklistReason)
+	})
+
+	t.Run("errBodyFailsClosedBlacklist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue:    "My PR Body",
+			BodyErrValue: errors.New("failure"),
+		}
+
+		actualBlacklist, _, err := IsPRBlacklisted(ctx, pc, mergeConfig.Blacklist)
+		require.NotNil(t, err)
+		assert.True(t, actualBlacklist)
+	})
+
+	t.Run("errBodyFailsClosedWhitelist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			BodyValue:    "My PR Body",
+			BodyErrValue: errors.New("failure"),
+		}
+
+		actualWhitelist, _, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
+		require.NotNil(t, err)
+		assert.False(t, actualWhitelist)
+	})
+
+	t.Run("errLabelFailsClosedWhitelist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			LabelErrValue: errors.New("failure"),
+		}
+
+		actualWhitelist, _, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
+		require.NotNil(t, err)
+		assert.False(t, actualWhitelist)
+	})
+
+	t.Run("errCommentsFailsClosedWhitelist", func(t *testing.T) {
+		pc := &pulltest.MockPullContext{
+			CommentErrValue: errors.New("failure"),
+		}
+
+		actualWhitelist, _, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)
+		require.NotNil(t, err)
+		assert.False(t, actualWhitelist)
 	})
 }
 


### PR DESCRIPTION
Right now we compare comment substrings on both comments and the PR body. In some cases,
it should be possible to lock down evaluation to only the PR body, instead of comments
_and_ the pr body.

Users who submit PRs do not have write access to the repo, so they cannot add a label.
For comments, anyone with read access to the repo can add a comment on any PR.

However, only someone with write access (or the Author) can edit the PR description.

Fixes #68

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/69)
<!-- Reviewable:end -->
