### PR TITLE
Add ability to take part of pull-request body as pr description instead of all or nothing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ version: 1
 # missing, bulldozer will consider all pull requests and use default settings.
 merge:
   # "whitelist" defines the set of pull requests considered by bulldozer. If
-  # the section is missing, bulldozer considers all pull requests not excluded 
+  # the section is missing, bulldozer considers all pull requests not excluded
   # by the blacklist.
   whitelist:
     # Pull requests with any of these labels (case-insensitive) are added to
@@ -112,6 +112,9 @@ merge:
       # generating a squash commit. The options are "pull_request_body",
       # "summarize_commits", and "empty_body".
       body: "summarize_commits"
+      # if "body" is "pull_request_body" then the commit message will be part
+      # of the pull request body delinated by "message_delimiter" string
+      message_delimiter: ==COMMIT_MSG==
 
   # "required_status" is a list of additional status contexts that must pass
   # before bulldozer can merge a pull request. This is useful if you want to
@@ -155,6 +158,21 @@ merge:
     squash:
       body: summarize_commits # or `pull_request_body`, `empty_body`
 ```
+
+You can also define part of pull request body to pick as a commit message when
+`body` is `pull_request_body`.
+
+```yaml
+merge:
+  method: squash
+  options:
+    squash:
+      body: pull_request_body
+      message_delimiter: ==COMMIT_MSG==
+```
+
+Anything that's contained between two `==COMMIT_MSG==` strings will become the
+commit message instead of whole pull request body.
 
 #### Bulldozer isn't merging my commit or updating my branch when it should, what could be happening?
 

--- a/bulldozer/config_fetcher.go
+++ b/bulldozer/config_fetcher.go
@@ -25,6 +25,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var commitMsgString = "==COMMIT_MSG=="
+
 type FetchedConfig struct {
 	Owner  string
 	Repo   string
@@ -176,7 +178,7 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
 				Options: map[MergeMethod]MergeOption{
-					configv0.Strategy: {SummarizeCommits},
+					configv0.Strategy: {SummarizeCommits, nil},
 				},
 			},
 		}
@@ -195,7 +197,7 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
 				Options: map[MergeMethod]MergeOption{
-					configv0.Strategy: {SummarizeCommits},
+					configv0.Strategy: {SummarizeCommits, nil},
 				},
 			},
 		}
@@ -214,7 +216,7 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
 				Options: map[MergeMethod]MergeOption{
-					configv0.Strategy: {PullRequestBody},
+					configv0.Strategy: {PullRequestBody, &commitMsgString},
 				},
 			},
 		}

--- a/bulldozer/config_fetcher.go
+++ b/bulldozer/config_fetcher.go
@@ -178,7 +178,7 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
 				Options: map[MergeMethod]MergeOption{
-					configv0.Strategy: {SummarizeCommits, nil},
+					configv0.Strategy: {Body: SummarizeCommits},
 				},
 			},
 		}
@@ -197,7 +197,7 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
 				Options: map[MergeMethod]MergeOption{
-					configv0.Strategy: {SummarizeCommits, nil},
+					configv0.Strategy: {Body: SummarizeCommits},
 				},
 			},
 		}

--- a/bulldozer/config_fetcher.go
+++ b/bulldozer/config_fetcher.go
@@ -25,8 +25,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var commitMsgString = "==COMMIT_MSG=="
-
 type FetchedConfig struct {
 	Owner  string
 	Repo   string
@@ -216,7 +214,7 @@ func (cf *ConfigFetcher) unmarshalConfigV0(bytes []byte) (*Config, error) {
 				DeleteAfterMerge: configv0.DeleteAfterMerge,
 				Method:           configv0.Strategy,
 				Options: map[MergeMethod]MergeOption{
-					configv0.Strategy: {PullRequestBody, &commitMsgString},
+					configv0.Strategy: {PullRequestBody, "==COMMIT_MSG=="},
 				},
 			},
 		}

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -53,7 +53,8 @@ type MergeConfig struct {
 }
 
 type MergeOption struct {
-	Body MessageStrategy `yaml:"body"`
+	Body                       MessageStrategy `yaml:"body"`
+	CommitDescriptionDelimiter *string         `yaml:"commit_description_delimiter,optional"`
 }
 
 type UpdateConfig struct {

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -53,8 +53,8 @@ type MergeConfig struct {
 }
 
 type MergeOption struct {
-	Body                       MessageStrategy `yaml:"body"`
-	CommitDescriptionDelimiter *string         `yaml:"commit_description_delimiter,optional"`
+	Body             MessageStrategy `yaml:"body"`
+	MessageDelimiter string          `yaml:"message_delimiter"`
 }
 
 type UpdateConfig struct {

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -58,16 +58,13 @@ func MergePR(ctx context.Context, pullCtx pull.Context, client *github.Client, m
 				return errors.Wrap(err, "failed to determine pull request body")
 			}
 
-			if opt.CommitDescriptionDelimiter != nil {
-				var rString = fmt.Sprintf(
-					`(?sm:(%s\s*)^(.*)$(\s*%s))`, *opt.CommitDescriptionDelimiter, *opt.CommitDescriptionDelimiter)
+			commitMessage = body
+			if opt.MessageDelimiter != "" {
+				var quotedDelimiter = regexp.QuoteMeta(opt.MessageDelimiter)
+				var rString = fmt.Sprintf(`(?sm:(%s\s*)^(.*)$(\s*%s))`, quotedDelimiter, quotedDelimiter)
 				if m := regexp.MustCompile(rString).FindStringSubmatch(body); len(m) == 4 {
 					commitMessage = m[2]
-				} else {
-					commitMessage = body
 				}
-			} else {
-				commitMessage = body
 			}
 		case SummarizeCommits:
 			summarizedMessages, err := summarizeCommitMessages(ctx, pullCtx, client)

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -48,7 +48,7 @@ func MergePR(ctx context.Context, pullCtx pull.Context, client *github.Client, m
 		opt, ok := mergeConfig.Options[SquashAndMerge]
 		if !ok {
 			logger.Error().Msgf("Unable to find matching %s in merge option configuration; using default %s", SquashAndMerge, EmptyBody)
-			opt = MergeOption{EmptyBody, nil}
+			opt = MergeOption{Body: EmptyBody}
 		}
 
 		switch opt.Body {


### PR DESCRIPTION
Previously bulldozer only supported summarize_commits mode or pull_request_body (with a caveat that you had to specify ==SQUASH_MSG==/==COMMIT_MSG== for the description part). Currently there's no clear alternative to the second mode. More importantly the feature I am after (and happy to change implementation as you think is appropriate) is to allow part of the pr description to be the commit description. This would be very useful for cases of auto generated prs that might have long descriptions but should be summarized in the git log in more succinct way (this is particularly annoying with github where it tracks mentions in commit descriptions for any commit interaction leading to a lot of notifications for creators of automated checks). 

Hence, I propose we standardise the feature we had previously and for pull_request_body mode add ability to select part of the pr description delineated by commit_description_delimiter paramter values.

Let me know what you think.

cc @ferozco

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/72)
<!-- Reviewable:end -->
