### PR TITLE
Fix first_commit_title strategy

### DIFF
--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -226,7 +226,7 @@ func calculateCommitTitle(ctx context.Context, pullCtx pull.Context, option Squa
 			return "", err
 		}
 		// commits are ordered from oldest to newest, must have at least one to make a PR
-		title = strings.SplitN(commits[0].Message, "\n", 1)[0]
+		title = strings.SplitN(commits[0].Message, "\n", 2)[0]
 	case GithubDefaultTitle:
 	}
 

--- a/bulldozer/merge_test.go
+++ b/bulldozer/merge_test.go
@@ -51,6 +51,16 @@ func TestCalculateCommitTitle(t *testing.T) {
 			Strategy:    FirstCommitTitle,
 			Output:      "The first commit message! (#12)",
 		},
+		"firstCommitTitleMultiline": {
+			PullContext: &pulltest.MockPullContext{
+				NumberValue: 12,
+				CommitsValue: []*pull.Commit{
+					{SHA: "409c973bbaa5e5e6d8cb0b057f2e74398577aaa0", Message: "This is the title\n\nThe message has\nmore lines\n"},
+				},
+			},
+			Strategy: FirstCommitTitle,
+			Output:   "This is the title (#12)",
+		},
 		"githubDefaultTitle": {
 			PullContext: defaultPullContext,
 			Strategy:    GithubDefaultTitle,


### PR DESCRIPTION
The old implementation failed to extract the first line from multi-line
commit messages; the argument to SplitN is the max number of results,
not the max number of splits.

I really should have added the test for this in the original PR. ☹️ 