### PR TITLE
Refactor GitHub client usage for merges

### DIFF
--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -45,10 +45,9 @@ func TestSimpleXListed(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("errBodyFailsClosedBlacklist", func(t *testing.T) {
+	t.Run("errCommentFailsClosedBlacklist", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
-			BodyValue:    "My PR Body",
-			BodyErrValue: errors.New("failure"),
+			CommentErrValue: errors.New("failure"),
 		}
 
 		actualBlacklist, _, err := IsPRBlacklisted(ctx, pc, mergeConfig.Blacklist)
@@ -56,10 +55,9 @@ func TestSimpleXListed(t *testing.T) {
 		assert.True(t, actualBlacklist)
 	})
 
-	t.Run("errBodyFailsClosedWhitelist", func(t *testing.T) {
+	t.Run("errCommentFailsClosedWhitelist", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
-			BodyValue:    "My PR Body",
-			BodyErrValue: errors.New("failure"),
+			CommentErrValue: errors.New("failure"),
 		}
 
 		actualWhitelist, _, err := IsPRWhitelisted(ctx, pc, mergeConfig.Whitelist)

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -136,13 +136,12 @@ func MergePR(ctx context.Context, pullCtx pull.Context, client *github.Client, m
 					ref := fmt.Sprintf("refs/heads/%s", head)
 
 					// check other open PRs to make sure that nothing is trying to merge into the ref we're about to delete
-					prs, err := pull.ListOpenPullRequestsForRef(ctx, client, pullCtx.Owner(), pullCtx.Repo(), ref)
+					isTargeted, err := pullCtx.IsTargeted(ctx)
 					if err != nil {
-						logger.Error().Err(errors.WithStack(err)).Msgf("Unable to list open prs against ref %s to compare delete request", ref)
+						logger.Error().Err(err).Msgf("Unable to determine if ref %s is targeted by other open pull requests before deletion", ref)
 						return
 					}
-
-					if len(prs) > 0 {
+					if isTargeted {
 						logger.Info().Msgf("Unable to delete ref %s after merging %q because there are open PRs against this ref", ref, pullCtx.Locator())
 						return
 					}

--- a/bulldozer/signals.go
+++ b/bulldozer/signals.go
@@ -58,10 +58,7 @@ func (s *Signals) Matches(ctx context.Context, pullCtx pull.Context, tag string)
 		}
 	}
 
-	body, err := pullCtx.Body(ctx)
-	if err != nil {
-		return false, "unable to get pull request body", err
-	}
+	body := pullCtx.Body()
 	comments, err := pullCtx.Comments(ctx)
 	if err != nil {
 		return false, "unable to list pull request comments", err
@@ -95,7 +92,7 @@ func (s *Signals) Matches(ctx context.Context, pullCtx pull.Context, tag string)
 		}
 	}
 
-	targetBranch, _, err := pullCtx.Branches(ctx)
+	targetBranch, _ := pullCtx.Branches()
 	if err != nil {
 		return false, "unable to get pull request branches", err
 	}

--- a/pull/context.go
+++ b/pull/context.go
@@ -25,24 +25,34 @@ import (
 // A new Context should be created each time a Pull Request is being evaluated
 // such that implementations are not required to consider cache invalidation.
 type Context interface {
-	// The Pull Request repository owner
+	// Owner returns the pull request repository owner.
 	Owner() string
 
-	// The Pull Request repository name
+	// Repo returns the pull request repository name.
 	Repo() string
 
-	// The Pull Request Number
+	// Number returns the pull request number.
 	Number() int
 
 	// Locator returns a locator string for the pull request. The locator
 	// string is formatted as "<owner>/<repository>#<number>"
 	Locator() string
 
-	// Title returns the pull request title
-	Title(ctx context.Context) (string, error)
+	// Title returns the pull request title.
+	Title() string
 
-	// Body returns the pull request body
-	Body(ctx context.Context) (string, error)
+	// Body returns the pull request body.
+	Body() string
+
+	// Branches returns the base (also known as target) and head branch names
+	// of this pull request. Branches in this repository have no prefix, while
+	// branches in forks are prefixed with the owner of the fork and a colon.
+	// The base branch will always be unprefixed.
+	Branches() (base string, head string)
+
+	// MergeState returns the current mergability of the pull request. It
+	// always returns the most up-to-date state possible.
+	MergeState(ctx context.Context) (*MergeState, error)
 
 	// RequiredStatuses returns the names of the required status
 	// checks for the pull request.
@@ -60,12 +70,11 @@ type Context interface {
 
 	// Labels lists all labels on the pull request.
 	Labels(ctx context.Context) ([]string, error)
+}
 
-	// Branches returns the base (also known as target) and head branch names
-	// of this pull request. Branches in this repository have no prefix, while
-	// branches in forks are prefixed with the owner of the fork and a colon.
-	// The base branch will always be unprefixed.
-	Branches(ctx context.Context) (base string, head string, err error)
+type MergeState struct {
+	Closed    bool
+	Mergeable *bool
 }
 
 type Commit struct {

--- a/pull/context.go
+++ b/pull/context.go
@@ -70,6 +70,10 @@ type Context interface {
 
 	// Labels lists all labels on the pull request.
 	Labels(ctx context.Context) ([]string, error)
+
+	// IsTargeted returns true if the head branch of this pull request is the
+	// target branch of other open PRs on the repository.
+	IsTargeted(ctx context.Context) (bool, error)
 }
 
 type MergeState struct {

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -230,5 +230,15 @@ func (ghc *GithubContext) Labels(ctx context.Context) ([]string, error) {
 	return labelNames, nil
 }
 
+func (ghc *GithubContext) IsTargeted(ctx context.Context) (bool, error) {
+	ref := fmt.Sprintf("refs/heads/%s", ghc.pr.GetHead().GetRef())
+
+	prs, err := ListOpenPullRequestsForRef(ctx, ghc.client, ghc.owner, ghc.repo, ref)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to determine targeted status")
+	}
+	return len(prs) > 0, nil
+}
+
 // type assertion
 var _ Context = &GithubContext{}

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -40,14 +40,14 @@ type GithubContext struct {
 	successStatuses  []string
 }
 
-func NewGithubContext(client *github.Client, pr *github.PullRequest, owner, repo string, number int) Context {
+func NewGithubContext(client *github.Client, pr *github.PullRequest) Context {
 	return &GithubContext{
 		client: client,
 
 		pr:     pr,
-		owner:  owner,
-		repo:   repo,
-		number: number,
+		owner:  pr.GetBase().GetRepo().GetOwner().GetLogin(),
+		repo:   pr.GetBase().GetRepo().GetName(),
+		number: pr.GetNumber(),
 	}
 }
 
@@ -67,12 +67,24 @@ func (ghc *GithubContext) Locator() string {
 	return fmt.Sprintf("%s/%s#%d", ghc.owner, ghc.repo, ghc.number)
 }
 
-func (ghc *GithubContext) Title(ctx context.Context) (string, error) {
-	return ghc.pr.GetTitle(), nil
+func (ghc *GithubContext) Title() string {
+	return ghc.pr.GetTitle()
 }
 
-func (ghc *GithubContext) Body(ctx context.Context) (string, error) {
-	return ghc.pr.GetBody(), nil
+func (ghc *GithubContext) Body() string {
+	return ghc.pr.GetBody()
+}
+
+func (ghc *GithubContext) MergeState(ctx context.Context) (*MergeState, error) {
+	pr, _, err := ghc.client.PullRequests.Get(ctx, ghc.owner, ghc.repo, ghc.number)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get pull request merge state")
+	}
+
+	return &MergeState{
+		Closed:    pr.GetState() == "closed",
+		Mergeable: pr.Mergeable,
+	}, nil
 }
 
 func (ghc *GithubContext) Comments(ctx context.Context) ([]string, error) {
@@ -197,10 +209,10 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 	return ghc.successStatuses, nil
 }
 
-func (ghc *GithubContext) Branches(ctx context.Context) (base string, head string, err error) {
+func (ghc *GithubContext) Branches() (base string, head string) {
 	base = ghc.pr.GetBase().GetRef()
 
-	// Check for forks
+	// if the repository is a fork, use label to include the owner prefix
 	if ghc.pr.GetHead().GetRepo().GetID() == ghc.pr.GetBase().GetRepo().GetID() {
 		head = ghc.pr.GetHead().GetRef()
 	} else {

--- a/pull/pulltest/mock_context.go
+++ b/pull/pulltest/mock_context.go
@@ -26,13 +26,15 @@ type MockPullContext struct {
 	RepoValue   string
 	NumberValue int
 
-	TitleValue    string
-	TitleErrValue error
-
+	TitleValue   string
 	BodyValue    string
-	BodyErrValue error
-
 	LocatorValue string
+
+	BranchBase string
+	BranchName string
+
+	MergeStateValue    *pull.MergeState
+	MergeStateErrValue error
 
 	LabelValue    []string
 	LabelErrValue error
@@ -48,10 +50,6 @@ type MockPullContext struct {
 
 	SuccessStatusesValue    []string
 	SuccessStatusesErrValue error
-
-	BranchBase     string
-	BranchName     string
-	BranchErrValue error
 }
 
 func (c *MockPullContext) Owner() string {
@@ -73,12 +71,20 @@ func (c *MockPullContext) Locator() string {
 	return "pulltest/context#1"
 }
 
-func (c *MockPullContext) Title(ctx context.Context) (string, error) {
-	return c.TitleValue, c.TitleErrValue
+func (c *MockPullContext) Title() string {
+	return c.TitleValue
 }
 
-func (c *MockPullContext) Body(ctx context.Context) (string, error) {
-	return c.BodyValue, c.BodyErrValue
+func (c *MockPullContext) Body() string {
+	return c.BodyValue
+}
+
+func (c *MockPullContext) Branches() (base string, head string) {
+	return c.BranchBase, c.BranchName
+}
+
+func (c *MockPullContext) MergeState(ctx context.Context) (*pull.MergeState, error) {
+	return c.MergeStateValue, c.MergeStateErrValue
 }
 
 func (c *MockPullContext) Comments(ctx context.Context) ([]string, error) {
@@ -95,10 +101,6 @@ func (c *MockPullContext) RequiredStatuses(ctx context.Context) ([]string, error
 
 func (c *MockPullContext) CurrentSuccessStatuses(ctx context.Context) ([]string, error) {
 	return c.SuccessStatusesValue, c.SuccessStatusesErrValue
-}
-
-func (c *MockPullContext) Branches(ctx context.Context) (base string, head string, err error) {
-	return c.BranchBase, c.BranchName, c.BranchErrValue
 }
 
 func (c *MockPullContext) Labels(ctx context.Context) ([]string, error) {

--- a/pull/pulltest/mock_context.go
+++ b/pull/pulltest/mock_context.go
@@ -50,6 +50,9 @@ type MockPullContext struct {
 
 	SuccessStatusesValue    []string
 	SuccessStatusesErrValue error
+
+	IsTargetedValue    bool
+	IsTargetedErrValue error
 }
 
 func (c *MockPullContext) Owner() string {
@@ -105,6 +108,10 @@ func (c *MockPullContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 
 func (c *MockPullContext) Labels(ctx context.Context) ([]string, error) {
 	return c.LabelValue, c.LabelErrValue
+}
+
+func (c *MockPullContext) IsTargeted(ctx context.Context) (bool, error) {
+	return c.IsTargetedValue, c.IsTargetedErrValue
 }
 
 // type assertion

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -53,7 +53,7 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 		}
 		if shouldMerge {
 			logger.Debug().Msg("Pull request should be merged")
-			if err := bulldozer.MergePR(ctx, pullCtx, client, config.Merge); err != nil {
+			if err := bulldozer.MergePR(ctx, pullCtx, bulldozer.NewGitHubMerger(client), config.Merge); err != nil {
 				return errors.Wrap(err, "failed to merge pull request")
 			}
 		}

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -55,7 +55,7 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	if err != nil {
 		return errors.Wrapf(err, "failed to get pull request %s/%s#%d", owner, repoName, number)
 	}
-	pullCtx := pull.NewGithubContext(client, pr, owner, repoName, number)
+	pullCtx := pull.NewGithubContext(client, pr)
 
 	if err := h.ProcessPullRequest(ctx, pullCtx, client, pr); err != nil {
 		logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -60,7 +60,7 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	if err != nil {
 		return errors.Wrapf(err, "failed to get pull request %s/%s#%d", owner, repoName, number)
 	}
-	pullCtx := pull.NewGithubContext(client, pr, owner, repoName, number)
+	pullCtx := pull.NewGithubContext(client, pr)
 
 	if err := h.ProcessPullRequest(ctx, pullCtx, client, pr); err != nil {
 		logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -55,7 +55,7 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 	if err != nil {
 		return errors.Wrapf(err, "failed to get pull request %s/%s#%d", owner, repoName, number)
 	}
-	pullCtx := pull.NewGithubContext(client, pr, owner, repoName, number)
+	pullCtx := pull.NewGithubContext(client, pr)
 
 	if err := h.ProcessPullRequest(ctx, pullCtx, client, pr); err != nil {
 		logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")

--- a/server/handler/push.go
+++ b/server/handler/push.go
@@ -73,7 +73,7 @@ func (h *Push) Handle(ctx context.Context, eventType, deliveryID string, payload
 	}
 
 	for _, pr := range prs {
-		pullCtx := pull.NewGithubContext(client, pr, owner, repoName, pr.GetNumber())
+		pullCtx := pull.NewGithubContext(client, pr)
 		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
 
 		logger.Debug().Msgf("checking status for updated sha %s", baseRef)

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -66,7 +66,7 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 	}
 
 	for _, pr := range prs {
-		pullCtx := pull.NewGithubContext(client, pr, owner, repoName, pr.GetNumber())
+		pullCtx := pull.NewGithubContext(client, pr)
 		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
 		if err := h.ProcessPullRequest(logger.WithContext(ctx), pullCtx, client, pr); err != nil {
 			logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")


### PR DESCRIPTION
Add additional methods to `pull.Context` (and clean up some of the existing ones) so that `bulldozer.MergePR` can operate without any direct references to a `github.Client`. This improves testability (although I don't add any new tests here) and enables a fix for #98 that I'll add in a followup PR.

Fixes #100.