### PR TITLE
Add support for merging to restricted branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Anything that's contained between two `==COMMIT_MSG==` strings will become the
 commit message instead of whole pull request body.
 
 #### What if I don't want to put config files into each repo?
+
 You can add default repository configuration in your bulldozer config file.
 
 It will be used only when your repo config file does not exist.
@@ -214,9 +215,38 @@ which are to be expected, and others that may be caused by mis-configuring Bulld
 
 * Required status checks have not passed
 * Review requirements are not satisfied
-* The merge strategy configured in `.bulldozer.yml` is not allowed by your repository settings
-* Branch protection rules are preventing `bulldozer [bot]` from [pushing to the branch](https://help.github.com/articles/about-branch-restrictions/).
-  Unfortunately GitHub apps cannot be added to the list at this time.
+* The merge strategy configured in `.bulldozer.yml` is not allowed by your
+  repository settings
+* Branch protection rules are preventing `bulldozer[bot]` from [pushing to the
+  branch][push restrictions]. Unfortunately, GitHub apps cannot be added to
+  the list at this time, but there is [a workaround][] if you are running your
+  own Bulldozer server.
+
+[push restrictions]: https://help.github.com/articles/about-branch-restrictions/
+[a workaround]: #can-bulldozer-work-with-push-restrictions-on-branches
+
+#### Can Bulldozer work with push restrictions on branches?
+
+As mentioned above, GitHub Apps cannot be added to the list of users associated
+with [push restrictions][]. To work around this, you can:
+
+1. Use another app like [policy-bot](https://github.com/palantir/policy-bot) to
+   implement _approval_ restrictions as required status checks instead of using
+   push restrictions. This effectively limits who can push to a branch by
+   requiring changes to go through the pull request process and be approved.
+
+2. Configure Bulldozer to use a personal access token for a regular user to
+   perform merges in this case. The token must have the `repo` scope and the
+   user must be allowed to push to the branch. In the server configuration
+   file, set:
+
+   ```yaml
+   options:
+     restriction_user_token: <token-value>
+   ```
+
+   The token is _only_ used if the target branch has push restrictions enabled.
+   All other merges are performed as the normal GitHub App user.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ with [push restrictions][]. To work around this, you can:
 
    ```yaml
    options:
-     restriction_user_token: <token-value>
+     push_restriction_user_token: <token-value>
    ```
 
    The token is _only_ used if the target branch has push restrictions enabled.

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -96,7 +96,7 @@ func (m *PushRestrictionMerger) Merge(ctx context.Context, pullCtx pull.Context,
 	}
 
 	if restricted {
-		zerolog.Ctx(ctx).Info().Msg("target branch has push restrictions, using restricted client for merge")
+		zerolog.Ctx(ctx).Info().Msg("Target branch has push restrictions, using restricted client for merge")
 		return m.Restricted.Merge(ctx, pullCtx, method, msg)
 	}
 	return m.Normal.Merge(ctx, pullCtx, method, msg)
@@ -111,7 +111,7 @@ func (m *PushRestrictionMerger) DeleteHead(ctx context.Context, pullCtx pull.Con
 	// this is not necessary: the normal client should have delete permissions,
 	// but having the merge user also delete the branch is a better UX
 	if restricted {
-		zerolog.Ctx(ctx).Info().Msg("target branch has push restrictions, using restricted client for delete")
+		zerolog.Ctx(ctx).Info().Msg("Target branch has push restrictions, using restricted client for delete")
 		return m.Restricted.DeleteHead(ctx, pullCtx)
 	}
 	return m.Normal.DeleteHead(ctx, pullCtx)

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -96,6 +96,7 @@ func (m *PushRestrictionMerger) Merge(ctx context.Context, pullCtx pull.Context,
 	}
 
 	if restricted {
+		zerolog.Ctx(ctx).Info().Msg("target branch has push restrictions, using restricted client for merge")
 		return m.Restricted.Merge(ctx, pullCtx, method, msg)
 	}
 	return m.Normal.Merge(ctx, pullCtx, method, msg)
@@ -110,6 +111,7 @@ func (m *PushRestrictionMerger) DeleteHead(ctx context.Context, pullCtx pull.Con
 	// this is not necessary: the normal client should have delete permissions,
 	// but having the merge user also delete the branch is a better UX
 	if restricted {
+		zerolog.Ctx(ctx).Info().Msg("target branch has push restrictions, using restricted client for delete")
 		return m.Restricted.DeleteHead(ctx, pullCtx)
 	}
 	return m.Normal.DeleteHead(ctx, pullCtx)
@@ -228,7 +230,7 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 						return
 					}
 
-					logger.Debug().Msgf("Attempting to delete ref %s", ref)
+					logger.Info().Msgf("Attempting to delete ref %s", ref)
 					if err := merger.DeleteHead(ctx, pullCtx); err != nil {
 						logger.Error().Err(err).Msgf("Failed to delete ref %s on %q", ref, pullCtx.Locator())
 						return

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -89,16 +89,16 @@ func NewPushRestrictionMerger(normal, restricted Merger) Merger {
 	}
 }
 
-func (m *PushRestrictionMerger) Merge(ctx context.Context, pullCtx pull.Context, message string, options *github.PullRequestOptions) (string, error) {
+func (m *PushRestrictionMerger) Merge(ctx context.Context, pullCtx pull.Context, method MergeMethod, msg CommitMessage) (string, error) {
 	restricted, err := pullCtx.PushRestrictions(ctx)
 	if err != nil {
 		return "", err
 	}
 
 	if restricted {
-		return m.Restricted.Merge(ctx, pullCtx, message, options)
+		return m.Restricted.Merge(ctx, pullCtx, method, msg)
 	}
-	return m.Normal.Merge(ctx, pullCtx, message, options)
+	return m.Normal.Merge(ctx, pullCtx, method, msg)
 }
 
 func (m *PushRestrictionMerger) DeleteHead(ctx context.Context, pullCtx pull.Context) error {

--- a/bulldozer/merge_test.go
+++ b/bulldozer/merge_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -34,7 +33,7 @@ type MockMerger struct {
 	DeleteError error
 }
 
-func (m *MockMerger) Merge(ctx context.Context, pullCtx pull.Context, message string, options *github.PullRequestOptions) (string, error) {
+func (m *MockMerger) Merge(ctx context.Context, pullCtx pull.Context, method MergeMethod, msg CommitMessage) (string, error) {
 	m.MergeCount++
 	return "deadbeef", m.MergeError
 }
@@ -106,7 +105,7 @@ func TestPushRestrictionMerger(t *testing.T) {
 	ctx := context.Background()
 	pullCtx := &pulltest.MockPullContext{}
 
-	_, _ = merger.Merge(ctx, pullCtx, "", nil)
+	_, _ = merger.Merge(ctx, pullCtx, SquashAndMerge, CommitMessage{})
 	assert.Equal(t, 1, normal.MergeCount, "normal merge was not called")
 	assert.Equal(t, 0, restricted.MergeCount, "restricted merge was incorrectly called")
 
@@ -116,7 +115,7 @@ func TestPushRestrictionMerger(t *testing.T) {
 
 	pullCtx.PushRestrictionsValue = true
 
-	_, _ = merger.Merge(ctx, pullCtx, "", nil)
+	_, _ = merger.Merge(ctx, pullCtx, SquashAndMerge, CommitMessage{})
 	assert.Equal(t, 1, normal.MergeCount, "normal merge was incorrectly called")
 	assert.Equal(t, 1, restricted.MergeCount, "restricted merge was not called")
 

--- a/config/bulldozer.example.yml
+++ b/config/bulldozer.example.yml
@@ -42,7 +42,7 @@ options:
   app_name: bulldozer
   # An optional personal access token associated with a normal GitHub user that
   # is used to merge pull requests into protected branches with push restrictions.
-  restriction_user_token: token
+  push_restriction_user_token: token
   # Default repository config, the same as the config file described in README
   default_repository_config:
     merge:

--- a/config/bulldozer.example.yml
+++ b/config/bulldozer.example.yml
@@ -40,6 +40,9 @@ options:
   # The name of the application. This will affect the User-Agent header
   # when making requests to Github.
   app_name: bulldozer
+  # An optional personal access token associated with a normal GitHub user that
+  # is used to merge pull requests into protected branches with push restrictions.
+  restriction_user_token: token
   # Default repository config, the same as the config file described in README
   default_repository_config:
     merge:

--- a/pull/context.go
+++ b/pull/context.go
@@ -58,6 +58,10 @@ type Context interface {
 	// checks for the pull request.
 	RequiredStatuses(ctx context.Context) ([]string, error)
 
+	// PushRestrictions returns true if the target barnch of the pull request
+	// restricts the users or teams that have push access.
+	PushRestrictions(ctx context.Context) (bool, error)
+
 	// CurrentSuccessStatuses returns the names of all currently
 	// successful status checks for the pull request.
 	CurrentSuccessStatuses(ctx context.Context) ([]string, error)

--- a/pull/pulltest/mock_context.go
+++ b/pull/pulltest/mock_context.go
@@ -48,6 +48,9 @@ type MockPullContext struct {
 	RequiredStatusesValue    []string
 	RequiredStatusesErrValue error
 
+	PushRestrictionsValue    bool
+	PushRestrictionsErrValue error
+
 	SuccessStatusesValue    []string
 	SuccessStatusesErrValue error
 
@@ -100,6 +103,10 @@ func (c *MockPullContext) Commits(ctx context.Context) ([]*pull.Commit, error) {
 
 func (c *MockPullContext) RequiredStatuses(ctx context.Context) ([]string, error) {
 	return c.RequiredStatusesValue, c.RequiredStatusesErrValue
+}
+
+func (c *MockPullContext) PushRestrictions(ctx context.Context) (bool, error) {
+	return c.PushRestrictionsValue, c.PushRestrictionsErrValue
 }
 
 func (c *MockPullContext) CurrentSuccessStatuses(ctx context.Context) ([]string, error) {

--- a/server/config.go
+++ b/server/config.go
@@ -46,7 +46,9 @@ type Options struct {
 	AppName                 string            `yaml:"app_name"`
 	ConfigurationPath       string            `yaml:"configuration_path"`
 	DefaultRepositoryConfig *bulldozer.Config `yaml:"default_repository_config"`
-	ConfigurationV0Paths    []string          `yaml:"configuration_v0_paths"`
+	RestrictionUserToken    string            `yaml:"restriction_user_token"`
+
+	ConfigurationV0Paths []string `yaml:"configuration_v0_paths"`
 }
 
 func (o *Options) fillDefaults() {

--- a/server/config.go
+++ b/server/config.go
@@ -43,10 +43,10 @@ type LoggingConfig struct {
 }
 
 type Options struct {
-	AppName                 string            `yaml:"app_name"`
-	ConfigurationPath       string            `yaml:"configuration_path"`
-	DefaultRepositoryConfig *bulldozer.Config `yaml:"default_repository_config"`
-	RestrictionUserToken    string            `yaml:"restriction_user_token"`
+	AppName                  string            `yaml:"app_name"`
+	ConfigurationPath        string            `yaml:"configuration_path"`
+	DefaultRepositoryConfig  *bulldozer.Config `yaml:"default_repository_config"`
+	PushRestrictionUserToken string            `yaml:"push_restriction_user_token"`
 
 	ConfigurationV0Paths []string `yaml:"configuration_v0_paths"`
 }

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -29,6 +29,8 @@ import (
 type Base struct {
 	githubapp.ClientCreator
 	bulldozer.ConfigFetcher
+
+	RestrictionUserToken string
 }
 
 func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, client *github.Client, pr *github.PullRequest) error {
@@ -37,6 +39,15 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 	bulldozerConfig, err := b.ConfigForPR(ctx, client, pr)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch configuration")
+	}
+
+	merger := bulldozer.NewGitHubMerger(client)
+	if b.RestrictionUserToken != "" {
+		tokenClient, err := b.NewTokenClient(b.RestrictionUserToken)
+		if err != nil {
+			return errors.Wrap(err, "failed to create token client")
+		}
+		merger = bulldozer.NewPushRestrictionMerger(merger, bulldozer.NewGitHubMerger(tokenClient))
 	}
 
 	switch {
@@ -53,7 +64,7 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 		}
 		if shouldMerge {
 			logger.Debug().Msg("Pull request should be merged")
-			if err := bulldozer.MergePR(ctx, pullCtx, bulldozer.NewGitHubMerger(client), config.Merge); err != nil {
+			if err := bulldozer.MergePR(ctx, pullCtx, merger, config.Merge); err != nil {
 				return errors.Wrap(err, "failed to merge pull request")
 			}
 		}

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -30,7 +30,7 @@ type Base struct {
 	githubapp.ClientCreator
 	bulldozer.ConfigFetcher
 
-	RestrictionUserToken string
+	PushRestrictionUserToken string
 }
 
 func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, client *github.Client, pr *github.PullRequest) error {
@@ -42,8 +42,8 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 	}
 
 	merger := bulldozer.NewGitHubMerger(client)
-	if b.RestrictionUserToken != "" {
-		tokenClient, err := b.NewTokenClient(b.RestrictionUserToken)
+	if b.PushRestrictionUserToken != "" {
+		tokenClient, err := b.NewTokenClient(b.PushRestrictionUserToken)
 		if err != nil {
 			return errors.Wrap(err, "failed to create token client")
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -64,8 +64,9 @@ func New(c *Config) (*Server, error) {
 	}
 
 	baseHandler := handler.Base{
-		ClientCreator: clientCreator,
-		ConfigFetcher: bulldozer.NewConfigFetcher(c.Options.ConfigurationPath, c.Options.ConfigurationV0Paths, c.Options.DefaultRepositoryConfig),
+		ClientCreator:        clientCreator,
+		ConfigFetcher:        bulldozer.NewConfigFetcher(c.Options.ConfigurationPath, c.Options.ConfigurationV0Paths, c.Options.DefaultRepositoryConfig),
+		RestrictionUserToken: c.Options.RestrictionUserToken,
 	}
 
 	webhookHandler := githubapp.NewDefaultEventDispatcher(c.Github,

--- a/server/server.go
+++ b/server/server.go
@@ -64,9 +64,10 @@ func New(c *Config) (*Server, error) {
 	}
 
 	baseHandler := handler.Base{
-		ClientCreator:        clientCreator,
-		ConfigFetcher:        bulldozer.NewConfigFetcher(c.Options.ConfigurationPath, c.Options.ConfigurationV0Paths, c.Options.DefaultRepositoryConfig),
-		RestrictionUserToken: c.Options.RestrictionUserToken,
+		ClientCreator: clientCreator,
+		ConfigFetcher: bulldozer.NewConfigFetcher(c.Options.ConfigurationPath, c.Options.ConfigurationV0Paths, c.Options.DefaultRepositoryConfig),
+
+		PushRestrictionUserToken: c.Options.PushRestrictionUserToken,
 	}
 
 	webhookHandler := githubapp.NewDefaultEventDispatcher(c.Github,


### PR DESCRIPTION
Users can configure a personal access token for a normal user and Bulldozer will use that token to merge into protected branches with push restrictions. This configuration is optional and only used when push restrictions are active.

Fixes #98 and requires #105 to merge first.