### PR TITLE
[WIP] Support Github Check Suites

### DIFF
--- a/server/handler/checksuite.go
+++ b/server/handler/checksuite.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/go-github/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+
+	"github.com/palantir/bulldozer/pull"
+)
+
+type CheckSuite struct {
+	Base
+}
+
+func (h *CheckSuite) Handles() []string {
+	return []string{"check_suite"}
+}
+
+func (h *CheckSuite) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.CheckSuiteEvent
+
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse status event payload")
+	}
+
+	repo := event.GetRepo()
+	installationID := githubapp.GetInstallationIDFromEvent(&event)
+	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
+	logger.Debug().Msg("NEW HANDLER")
+	if event.GetAction() != "completed" {
+		logger.Debug().Msgf("Doing nothing since check_run action was %q instead of 'completed'", event.GetAction())
+		return nil
+	}
+	suite := event.GetCheckSuite()
+
+	client, err := h.ClientCreator.NewInstallationClient(installationID)
+	if err != nil {
+		return errors.Wrap(err, "failed to instantiate github client")
+	}
+
+	prs := suite.PullRequests
+
+	if len(prs) == 0 {
+		logger.Debug().Msg("Doing nothing since status change event affects no open pull requests")
+		return nil
+	}
+
+	for _, pr := range prs {
+		pullCtx := pull.NewGithubContext(client, pr)
+		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
+		if err := h.ProcessPullRequest(logger.WithContext(ctx), pullCtx, client, pr); err != nil {
+			logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")
+		}
+	}
+
+	return nil
+}
+
+// type assertion
+var _ githubapp.EventHandler = &CheckSuite{}

--- a/server/server.go
+++ b/server/server.go
@@ -76,6 +76,7 @@ func New(c *Config) (*Server, error) {
 		&handler.PullRequestReview{Base: baseHandler},
 		&handler.Push{Base: baseHandler},
 		&handler.Status{Base: baseHandler},
+		&handler.CheckSuite{Base: baseHandler},
 	)
 
 	mux := base.Mux()


### PR DESCRIPTION
I'm trying to address #96 
As a first step I've tried to add a Handler for the `check_suite` webhook. It only differs in small details from the `status` one. Apparently I missed something in enabling the handler though, since in my test it never gets fired. I get a log like this:
> bulldozer_1  | 2019-04-05T09:24:03.657579750Z |INFO| Received webhook event github_delivery_id=a9e8ebd0-5782-11e9-8ae1-0c2e5b037836 github_event_type=check_suite rid=bijhtcqglpu77frvu2r0
bulldozer_1  | 2019-04-05T09:24:03.657636049Z |INFO| http_request elapsed=22.201649 method=POST path=/api/github/hook rid=bijhtcqglpu77frvu2r0 size=0 status=202

but nothing from the handler it seems. 

