### PR TITLE
Add support for Github Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Bulldozer requires the following permissions as a GitHub app:
 | Permission | Access | Reason |
 | ---------- | ------ | ------ |
 | Repository administration | Read-only | Determine required status checks |
+| Checks | Read-only | Read checks for ref |
 | Repository contents | Read & write | Read configuration, perform merges |
 | Issues | Read & write | Read comments, close linked issues |
 | Repository metadata | Read-only | Basic repository data |
@@ -282,6 +283,7 @@ Bulldozer requires the following permissions as a GitHub app:
 
 It should be subscribed to the following events:
 
+* Check run
 * Commit comment
 * Pull request
 * Status

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -224,9 +224,9 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 			opts.Page = res.NextPage
 		}
 
-		CheckOpts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
+		checkOpts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
 		for {
-			checkRuns, res, err := ghc.client.Checks.ListCheckRunsForRef(ctx, ghc.owner, ghc.repo, ghc.pr.GetHead().GetSHA(), CheckOpts)
+			checkRuns, res, err := ghc.client.Checks.ListCheckRunsForRef(ctx, ghc.owner, ghc.repo, ghc.pr.GetHead().GetSHA(), checkOpts)
 			if err != nil {
 				return ghc.successStatuses, errors.Wrapf(err, "cannot get check runs for SHA %s on %s", ghc.pr.GetHead().GetSHA(), ghc.Locator())
 			}
@@ -240,7 +240,7 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 			if res.NextPage == 0 {
 				break
 			}
-			CheckOpts.Page = res.NextPage
+			checkOpts.Page = res.NextPage
 		}
 
 		ghc.successStatuses = successStatuses

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -224,6 +224,25 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 			opts.Page = res.NextPage
 		}
 
+		check_opts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
+		for {
+			checkRuns, res, err := ghc.client.Checks.ListCheckRunsForRef(ctx, ghc.owner, ghc.repo, ghc.pr.GetHead().GetSHA(), check_opts)
+			if err != nil {
+				return ghc.successStatuses, errors.Wrapf(err, "cannot get check runs for SHA %s on %s", ghc.pr.GetHead().GetSHA(), ghc.Locator())
+			}
+
+			for _, s := range checkRuns.CheckRuns {
+				if s.GetConclusion() == "success" {
+					successStatuses = append(successStatuses, s.GetName())
+				}
+			}
+
+			if res.NextPage == 0 {
+				break
+			}
+			check_opts.Page = res.NextPage
+		}
+
 		ghc.successStatuses = successStatuses
 	}
 

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -224,9 +224,9 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 			opts.Page = res.NextPage
 		}
 
-		check_opts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
+		CheckOpts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
 		for {
-			checkRuns, res, err := ghc.client.Checks.ListCheckRunsForRef(ctx, ghc.owner, ghc.repo, ghc.pr.GetHead().GetSHA(), check_opts)
+			checkRuns, res, err := ghc.client.Checks.ListCheckRunsForRef(ctx, ghc.owner, ghc.repo, ghc.pr.GetHead().GetSHA(), CheckOpts)
 			if err != nil {
 				return ghc.successStatuses, errors.Wrapf(err, "cannot get check runs for SHA %s on %s", ghc.pr.GetHead().GetSHA(), ghc.Locator())
 			}
@@ -240,7 +240,7 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 			if res.NextPage == 0 {
 				break
 			}
-			check_opts.Page = res.NextPage
+			CheckOpts.Page = res.NextPage
 		}
 
 		ghc.successStatuses = successStatuses

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Palantir Technologies, Inc.
+ //
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+ // You may obtain a copy of the License at
+ //
+ //     http://www.apache.org/licenses/LICENSE-2.0
+ //
+ // Unless required by applicable law or agreed to in writing, software
+ // distributed under the License is distributed on an "AS IS" BASIS,
+ // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+
+  package handler
+
+  import (
+ 	"context"
+ 	"encoding/json"
+
+  	"github.com/google/go-github/github"
+ 	"github.com/palantir/go-githubapp/githubapp"
+ 	"github.com/pkg/errors"
+
+  	"github.com/palantir/bulldozer/pull"
+ )
+
+  type CheckRun struct {
+ 	Base
+ }
+
+  func (h *CheckRun) Handles() []string {
+ 	return []string{"check_run"}
+ }
+
+  func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+ 	var event github.CheckRunEvent
+
+  	if err := json.Unmarshal(payload, &event); err != nil {
+ 		return errors.Wrap(err, "failed to parse status event payload")
+ 	}
+
+ 	repo := event.GetRepo()
+ 	installationID := githubapp.GetInstallationIDFromEvent(&event)
+
+ 	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
+ 	logger.Debug().Msgf("Doing nothing since check_run action was %q instead of 'completed'", event.GetAction())
+
+
+ 	if event.GetAction() != "completed" {
+ 		logger.Debug().Msgf("Doing nothing since check_run action was %q instead of 'completed'", event.GetAction())
+ 		return nil
+ 	}
+ 	suite := event.GetCheckRun()
+
+  	client, err := h.ClientCreator.NewInstallationClient(installationID)
+ 	if err != nil {
+ 		return errors.Wrap(err, "failed to instantiate github client")
+ 	}
+
+  	prs := suite.PullRequests
+
+  	if len(prs) == 0 {
+ 		logger.Debug().Msg("Doing nothing since status change event affects no open pull requests")
+ 		return nil
+ 	}
+
+
+  	for _, pr := range prs {
+  		// The PR included in the CheckRun response is very slim on information.
+  		// It does not contain the owner information or label information we
+  		// need to process the pull request.
+
+  		full_pr, _, err := client.PullRequests.Get(ctx, repo.GetOwner().GetLogin(), repo.GetName(), pr.GetNumber())
+  		if err != nil {
+  			return errors.Wrapf(err, "failed to fetch PR number %q for CheckRun", pr.GetNumber())
+  		}
+ 		pullCtx := pull.NewGithubContext(client, full_pr)
+
+
+ 		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
+ 		if err := h.ProcessPullRequest(logger.WithContext(ctx), pullCtx, client, pr); err != nil {
+ 			logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")
+ 		}
+ 	}
+
+  	return nil
+ }
+
+  // type assertion
+ var _ githubapp.EventHandler = &CheckRun{}

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -49,15 +49,13 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 		logger.Debug().Msgf("Doing nothing since check_run action was %q instead of 'completed'", event.GetAction())
 		return nil
 	}
-	suite := event.GetCheckRun()
 
 	client, err := h.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {
 		return errors.Wrap(err, "failed to instantiate github client")
 	}
 
-	prs := suite.PullRequests
-
+	prs := event.GetCheckRun().PullRequests
 	if len(prs) == 0 {
 		logger.Debug().Msg("Doing nothing since status change event affects no open pull requests")
 		return nil

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -71,11 +71,11 @@
   		// It does not contain the owner information or label information we
   		// need to process the pull request.
 
-  		full_pr, _, err := client.PullRequests.Get(ctx, repo.GetOwner().GetLogin(), repo.GetName(), pr.GetNumber())
+  		fullPR, _, err := client.PullRequests.Get(ctx, repo.GetOwner().GetLogin(), repo.GetName(), pr.GetNumber())
   		if err != nil {
   			return errors.Wrapf(err, "failed to fetch PR number %q for CheckRun", pr.GetNumber())
   		}
- 		pullCtx := pull.NewGithubContext(client, full_pr)
+ 		pullCtx := pull.NewGithubContext(client, fullPR)
 
 
  		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -37,14 +37,13 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 	var event github.CheckRunEvent
 
 	if err := json.Unmarshal(payload, &event); err != nil {
-		return errors.Wrap(err, "failed to parse status event payload")
+		return errors.Wrap(err, "failed to parse check_run event payload")
 	}
 
 	repo := event.GetRepo()
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 
 	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
-	logger.Debug().Msgf("Doing nothing since check_run action was %q instead of 'completed'", event.GetAction())
 
 	if event.GetAction() != "completed" {
 		logger.Debug().Msgf("Doing nothing since check_run action was %q instead of 'completed'", event.GetAction())

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -1,16 +1,16 @@
 // Copyright 2018 Palantir Technologies, Inc.
- //
- // Licensed under the Apache License, Version 2.0 (the "License");
- // you may not use this file except in compliance with the License.
- // You may obtain a copy of the License at
- //
- //     http://www.apache.org/licenses/LICENSE-2.0
- //
- // Unless required by applicable law or agreed to in writing, software
- // distributed under the License is distributed on an "AS IS" BASIS,
- // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- // See the License for the specific language governing permissions and
- // limitations under the License.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
   package handler
 

--- a/server/server.go
+++ b/server/server.go
@@ -69,6 +69,7 @@ func New(c *Config) (*Server, error) {
 	}
 
 	webhookHandler := githubapp.NewDefaultEventDispatcher(c.Github,
+		&handler.CheckRun{Base: baseHandler},
 		&handler.IssueComment{Base: baseHandler},
 		&handler.PullRequest{Base: baseHandler},
 		&handler.PullRequestReview{Base: baseHandler},


### PR DESCRIPTION
Currently only Github status checks are supported. This change adds support for the newer Github Checks API.

This is based on https://github.com/palantir/bulldozer/pull/108.
I replaced the CheckSuite handler with a CheckRun one. CheckSuiteEvents are only sent only once per ref, whereas a CheckRun can be sent multiple times, in the case of the [WIP app](https://github.com/apps/wip).

This change requires updated permissions to allow us to lookup Checks for specific refs and to listen to CheckRunEvents.

Fixes #96