### PR TITLE
additional debugging for skipped branch deletions

### DIFF
--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -216,9 +216,10 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 
 			// if head is qualified (contains ":"), PR is from a fork and we don't have delete permission
 			if !strings.ContainsRune(head, ':') {
-				if mergeConfig.DeleteAfterMerge {
-					ref := fmt.Sprintf("refs/heads/%s", head)
+				
+				ref := fmt.Sprintf("refs/heads/%s", head)
 
+				if mergeConfig.DeleteAfterMerge {
 					// check other open PRs to make sure that nothing is trying to merge into the ref we're about to delete
 					isTargeted, err := pullCtx.IsTargeted(ctx)
 					if err != nil {

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -237,6 +237,8 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 					}
 
 					logger.Info().Msgf("Successfully deleted ref %s on %q", ref, pullCtx.Locator())
+				} else {
+					logger.Debug().Msgf("Skipping deletion of ref %s, delete_after_merge not configured", ref)	
 				}
 			} else {
 				logger.Debug().Msg("Pull Request is from a fork, not deleting")


### PR DESCRIPTION
We've run into an issue where branches are not being deleted despite setting `delete_after_merge: true`. This adds a log line to confirm the skipping of the delete step when `delete_after_merge` is false or not set.

related: #112 