### PR TITLE
Do not use pull request body as message if delimiters are not present

### DIFF
--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -258,7 +258,6 @@ func calculateCommitMessage(ctx context.Context, pullCtx pull.Context, option Sq
 	commitMessage := ""
 	switch option.Body {
 	case PullRequestBody:
-		commitMessage = pullCtx.Body()
 		if option.MessageDelimiter != "" {
 			var quotedDelimiter = regexp.QuoteMeta(option.MessageDelimiter)
 			var rString = fmt.Sprintf(`(?sm:(%s\s*)^(.*)$(\s*%s))`, quotedDelimiter, quotedDelimiter)
@@ -270,6 +269,8 @@ func calculateCommitMessage(ctx context.Context, pullCtx pull.Context, option Sq
 			if m := matcher.FindStringSubmatch(commitMessage); len(m) == 4 {
 				commitMessage = m[2]
 			}
+		} else {
+			commitMessage = pullCtx.Body()
 		}
 	case SummarizeCommits:
 		summarizedMessages, err := summarizeCommitMessages(ctx, pullCtx)


### PR DESCRIPTION
#72 merged quite a while ago but nearly all excavator PR still do not use the delimiters. Thus all excavator PRs have very long commit messages that make it cumbersome to view the commit history.

This PR changes the behavior to explicitly exclude the pull request body if the PR does not include the specified delimiter. Now, by default excavator PRs will not have their body included in the commit message unless the explicitly opt-in and include the delimiters.