### PR TITLE
Read some config values from the environment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -114,11 +114,11 @@
 
 [[projects]]
   branch = "develop"
-  digest = "1:101a94effb81347106e3eeb6ffdaa8debe02d011682fb9633b13a8dc75f59630"
+  digest = "1:f83177ebb2d551c3cf007135cfaa6a6f3ff30df6b5a898d4a5ad29c23725aab1"
   name = "github.com/palantir/go-githubapp"
   packages = ["githubapp"]
   pruneopts = "NUT"
-  revision = "9f023162a90f86c702017192b62d39a7e2fe32d7"
+  revision = "f84c07149e1af11d46150aaeb59181b30a5e550f"
 
 [[projects]]
   digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -114,11 +114,11 @@
 
 [[projects]]
   branch = "develop"
-  digest = "1:f83177ebb2d551c3cf007135cfaa6a6f3ff30df6b5a898d4a5ad29c23725aab1"
+  digest = "1:3a2593e6d2755d8fb6fd70f7310d10a1d25cf57edadf56e20e772b056007b807"
   name = "github.com/palantir/go-githubapp"
   packages = ["githubapp"]
   pruneopts = "NUT"
-  revision = "f84c07149e1af11d46150aaeb59181b30a5e550f"
+  revision = "e3527091824a277432abfb5754cd9f41b4e3cd1b"
 
 [[projects]]
   digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"

--- a/README.md
+++ b/README.md
@@ -275,17 +275,19 @@ We provide both a Docker container and a binary distribution of the server:
 - Binaries: https://bintray.com/palantir/releases/bulldozer
 - Docker Images: https://hub.docker.com/r/palantirtechnologies/bulldozer/
 
-A sample configuration file is provided at `config/bulldozer.example.yml`. We
-recommend deploying the application behind a reverse proxy or load balancer
-that terminates TLS connections.
+A sample configuration file is provided at `config/bulldozer.example.yml`.
+Certain values may also be set by environment variables; these are noted in the
+comments in the sample configuration file.
 
 ### GitHub App Configuration
 
-Webhook URL:
+To configure Bulldozer as a GitHub App, these general options are required:
 
-* `http(s)://your.domain.com/api/github/hook`
+- **Webhook URL**: `http(s)://<your-policy-bot-domain>/api/github/hook`
+- **Webhook secret**: A random string that matches the value of the
+  `github.app.webhook_secret` property in the server configuration
 
-Bulldozer requires the following permissions as a GitHub app:
+The app requires these permissions:
 
 | Permission | Access | Reason |
 | ---------- | ------ | ------ |
@@ -297,7 +299,7 @@ Bulldozer requires the following permissions as a GitHub app:
 | Pull requests | Read & write | Merge and close pull requests |
 | Commit status | Read-only | Evaluate pull request status |
 
-It should be subscribed to the following events:
+The app should be subscribed to these events:
 
 * Check run
 * Commit comment

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ comments in the sample configuration file.
 
 To configure Bulldozer as a GitHub App, these general options are required:
 
-- **Webhook URL**: `http(s)://<your-policy-bot-domain>/api/github/hook`
+- **Webhook URL**: `http(s)://<your-bulldozer-domain>/api/github/hook`
 - **Webhook secret**: A random string that matches the value of the
   `github.app.webhook_secret` property in the server configuration
 

--- a/config/bulldozer.example.yml
+++ b/config/bulldozer.example.yml
@@ -3,6 +3,11 @@ server:
   # The listen address and port
   address: "0.0.0.0"
   port: 8080
+  # Uncomment the "tls_config" block to enable HTTPS support in the server.
+  # The cert and key files must be usable by net/http.ListenAndServeTLS().
+  # tls_config:
+  #   cert_file: /path/to/server.pem
+  #   key_file: /path/to/server.key
 
 # Options for logging output
 logging:
@@ -21,16 +26,21 @@ cache:
 
 # Options for connecting to GitHub
 github:
-  # The URL of the GitHub homepage
+  # The URL of the GitHub homepage. Can also be set by the GITHUB_WEB_URL
+  # environment variable.
   web_url: "https://github.com"
-  # The base URL for v3 (REST) API requests
+  # The base URL for v3 (REST) API requests. Can also be set by the
+  # GITHUB_V3_API_URL environment variable.
   v3_api_url: "https://api.github.com"
   app:
-    # The integration ID of the GitHub app
+    # The integration ID of the GitHub app. Can also be set by the
+    # GITHUB_APP_INTEGRATION_ID environment variable.
     integration_id: 1
-    # A random string used to validate webhooks
+    # A random string used to validate webhooks. Can also be set by the
+    # GITHUB_APP_WEBHOOK_SECRET environment variable.
     webhook_secret: "app_secret"
-    # The private key of the GitHub app (pem file download from GitHub)
+    # The private key of the GitHub app (.pem file download from GitHub). Can
+    # also be set by the GITHUB_APP_PRIVATE_KEY environment variable.
     private_key: |
       -----BEGIN RSA PRIVATE KEY-----
       xxxxx
@@ -46,7 +56,9 @@ options:
   # when making requests to Github.
   app_name: bulldozer
   # An optional personal access token associated with a normal GitHub user that
-  # is used to merge pull requests into protected branches with push restrictions.
+  # is used to merge pull requests into protected branches with push
+  # restrictions. Can also be set by the BULLDOZER_PUSH_RESTRICTION_USER_TOKEN
+  # environment variable.
   push_restriction_user_token: token
   # Default repository config, the same as the config file described in README
   default_repository_config:

--- a/server/config.go
+++ b/server/config.go
@@ -15,6 +15,8 @@
 package server
 
 import (
+	"os"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/palantir/go-baseapp/baseapp/datadog"
@@ -23,11 +25,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/palantir/bulldozer/bulldozer"
-)
-
-const (
-	DefaultAppName             = "bulldozer"
-	DefaultConfigurationV1Path = ".bulldozer.v1.yml"
 )
 
 type Config struct {
@@ -57,21 +54,15 @@ type Options struct {
 	ConfigurationV0Paths []string `yaml:"configuration_v0_paths"`
 }
 
-func (o *Options) fillDefaults() {
-	if o.AppName == "" {
-		o.AppName = DefaultAppName
-	}
-
-	if o.ConfigurationPath == "" {
-		o.ConfigurationPath = DefaultConfigurationV1Path
-	}
-}
-
 func ParseConfig(bytes []byte) (*Config, error) {
 	var c Config
-	err := yaml.UnmarshalStrict(bytes, &c)
-	if err != nil {
+	if err := yaml.UnmarshalStrict(bytes, &c); err != nil {
 		return nil, errors.Wrapf(err, "failed unmarshaling yaml")
+	}
+
+	c.Github.SetValuesFromEnv("")
+	if v, ok := os.LookupEnv("BULLDOZER_PUSH_RESTRICTION_USER_TOKEN"); ok {
+		c.Options.PushRestrictionUserToken = v
 	}
 
 	return &c, nil

--- a/vendor/github.com/palantir/go-githubapp/githubapp/config.go
+++ b/vendor/github.com/palantir/go-githubapp/githubapp/config.go
@@ -14,6 +14,11 @@
 
 package githubapp
 
+import (
+	"os"
+	"strconv"
+)
+
 type Config struct {
 	WebURL   string `yaml:"web_url" json:"webUrl"`
 	V3APIURL string `yaml:"v3_api_url" json:"v3ApiUrl"`
@@ -29,4 +34,34 @@ type Config struct {
 		ClientID     string `yaml:"client_id" json:"clientId"`
 		ClientSecret string `yaml:"client_secret" json:"clientSecret"`
 	} `yaml:"oauth" json:"oauth"`
+}
+
+// SetValuesFromEnv sets values in the configuration from coresponding
+// environment variables, if they exist. The optional prefix is added to the
+// start of the environment variable names.
+func (c *Config) SetValuesFromEnv(prefix string) {
+	setStringFromEnv("GITHUB_WEB_URL", prefix, &c.WebURL)
+	setStringFromEnv("GITHUB_V3_API_URL", prefix, &c.V3APIURL)
+	setStringFromEnv("GITHUB_V4_API_URL", prefix, &c.V4APIURL)
+
+	setIntFromEnv("GITHUB_APP_INTEGRATION_ID", prefix, &c.App.IntegrationID)
+	setStringFromEnv("GITHUB_APP_WEBHOOK_SECRET", prefix, &c.App.WebhookSecret)
+	setStringFromEnv("GITHUB_APP_PRIVATE_KEY", prefix, &c.App.PrivateKey)
+
+	setStringFromEnv("GITHUB_OAUTH_CLIENT_ID", prefix, &c.OAuth.ClientID)
+	setStringFromEnv("GITHUB_OAUTH_CLIENT_SECRET", prefix, &c.OAuth.ClientSecret)
+}
+
+func setStringFromEnv(key, prefix string, value *string) {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		*value = v
+	}
+}
+
+func setIntFromEnv(key, prefix string, value *int) {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		if i, err := strconv.Atoi(v); err == nil {
+			*value = i
+		}
+	}
 }

--- a/vendor/github.com/palantir/go-githubapp/githubapp/dispatcher.go
+++ b/vendor/github.com/palantir/go-githubapp/githubapp/dispatcher.go
@@ -96,7 +96,7 @@ type eventDispatcher struct {
 // dispatcher from configuration using the default error and response
 // callbacks.
 func NewDefaultEventDispatcher(c Config, handlers ...EventHandler) http.Handler {
-	return NewEventDispatcher(handlers, c.App.WebhookSecret, nil)
+	return NewEventDispatcher(handlers, c.App.WebhookSecret)
 }
 
 // NewEventDispatcher creates an http.Handler that dispatches GitHub webhook

--- a/vendor/github.com/palantir/go-githubapp/githubapp/dispatcher.go
+++ b/vendor/github.com/palantir/go-githubapp/githubapp/dispatcher.go
@@ -16,6 +16,7 @@ package githubapp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/github"
@@ -41,16 +42,59 @@ type EventHandler interface {
 	Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error
 }
 
-type ErrorHandler func(http.ResponseWriter, *http.Request, error)
+// ErrorCallback is called when an event handler returns an error. The error
+// from the handler is passed directly as the final argument.
+type ErrorCallback func(w http.ResponseWriter, r *http.Request, err error)
+
+// ResponseCallback is called to send a response to GitHub after an event is
+// handled. It is passed the event type and a flag indicating if an event
+// handler was called for the event.
+type ResponseCallback func(w http.ResponseWriter, r *http.Request, event string, handled bool)
+
+// DispatcherOption configures properties of an event dispatcher.
+type DispatcherOption func(*eventDispatcher)
+
+// WithErrorCallback sets the error callback for an event dispatcher.
+func WithErrorCallback(onError ErrorCallback) DispatcherOption {
+	return func(d *eventDispatcher) {
+		if onError != nil {
+			d.onError = onError
+		}
+	}
+}
+
+// WithResponseCallback sets the response callback for an event dispatcher.
+func WithResponseCallback(onResponse ResponseCallback) DispatcherOption {
+	return func(d *eventDispatcher) {
+		if onResponse != nil {
+			d.onResponse = onResponse
+		}
+	}
+}
+
+// ValidationError is passed to error callbacks when the webhook payload fails
+// validation.
+type ValidationError struct {
+	EventType  string
+	DeliveryID string
+	Cause      error
+}
+
+func (ve ValidationError) Error() string {
+	return fmt.Sprintf("invalid event: %v", ve.Cause)
+}
 
 type eventDispatcher struct {
 	handlerMap map[string]EventHandler
 	secret     string
-	onError    ErrorHandler
+
+	onError    ErrorCallback
+	onResponse ResponseCallback
 }
 
-// NewDefaultEventDispatcher is a convenience method to create an
-// EventDispatcher from configuration using the default error handler.
+// NewDefaultEventDispatcher is a convenience method to create an event
+// dispatcher from configuration using the default error and response
+// callbacks.
 func NewDefaultEventDispatcher(c Config, handlers ...EventHandler) http.Handler {
 	return NewEventDispatcher(handlers, c.App.WebhookSecret, nil)
 }
@@ -59,10 +103,9 @@ func NewDefaultEventDispatcher(c Config, handlers ...EventHandler) http.Handler 
 // requests to the appropriate event handlers. It validates payload integrity
 // using the given secret value.
 //
-// If an error occurs during handling, the error handler is called with the
-// error and should write an appropriate response. If the error handler is nil,
-// a default handler is used.
-func NewEventDispatcher(handlers []EventHandler, secret string, onError ErrorHandler) http.Handler {
+// Responses are controlled by optional error and response callbacks. If these
+// options are not provided, default callbacks are used.
+func NewEventDispatcher(handlers []EventHandler, secret string, opts ...DispatcherOption) http.Handler {
 	handlerMap := make(map[string]EventHandler)
 
 	// Iterate in reverse so the first entries in the slice have priority
@@ -72,67 +115,129 @@ func NewEventDispatcher(handlers []EventHandler, secret string, onError ErrorHan
 		}
 	}
 
-	if onError == nil {
-		onError = DefaultErrorHandler
-	}
-
-	return &eventDispatcher{
+	d := &eventDispatcher{
 		handlerMap: handlerMap,
 		secret:     secret,
-		onError:    onError,
+		onError:    DefaultErrorCallback,
+		onResponse: DefaultResponseCallback,
 	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
 }
 
-// ServeHTTP to implement http.Handler
+// ServeHTTP processes a webhook request from GitHub.
 func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// initialize context for SetResponder/GetResponder
+	// we store a pointer in the context so that functions deeper in the call
+	// tree can modify the value without creating a new context
+	var responder func(http.ResponseWriter, *http.Request)
+	ctx = context.WithValue(ctx, responderKey{}, &responder)
+	r = r.WithContext(ctx)
+
 	eventType := r.Header.Get("X-GitHub-Event")
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+
 	if eventType == "" {
-		// ACK payload that was received but won't be processed
-		w.WriteHeader(http.StatusAccepted)
+		d.onError(w, r, ValidationError{
+			EventType:  eventType,
+			DeliveryID: deliveryID,
+			Cause:      errors.New("missing event type"),
+		})
 		return
 	}
-	deliveryID := r.Header.Get("X-GitHub-Delivery")
 
 	logger := zerolog.Ctx(ctx).With().
 		Str(LogKeyEventType, eventType).
 		Str(LogKeyDeliveryID, deliveryID).
 		Logger()
 
-	// update context and request to contain new log fields
+	// initialize context with event logger
 	ctx = logger.WithContext(ctx)
 	r = r.WithContext(ctx)
 
 	payloadBytes, err := github.ValidatePayload(r, []byte(d.secret))
 	if err != nil {
-		d.onError(w, r, errors.Wrapf(err, "failed to validate webhook payload"))
+		d.onError(w, r, ValidationError{
+			EventType:  eventType,
+			DeliveryID: deliveryID,
+			Cause:      err,
+		})
 		return
 	}
 
 	logger.Info().Msgf("Received webhook event")
-	handler, ok := d.handlerMap[eventType]
 
-	switch {
-	case ok:
+	handler, ok := d.handlerMap[eventType]
+	if ok {
 		if err := handler.Handle(ctx, eventType, deliveryID, payloadBytes); err != nil {
-			// pass error directly so handler can inspect types if needed
 			d.onError(w, r, err)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
-	case eventType == "ping":
-		w.WriteHeader(http.StatusOK)
-	default:
+	}
+	d.onResponse(w, r, eventType, ok)
+}
+
+// DefaultErrorCallback logs errors and responds with a 500 status code.
+func DefaultErrorCallback(w http.ResponseWriter, r *http.Request, err error) {
+	logger := zerolog.Ctx(r.Context())
+
+	if ve, ok := err.(ValidationError); ok {
+		logger.Warn().Err(ve.Cause).Msgf("Received invalid webhook headers or payload")
+		http.Error(w, "Invalid webhook headers or payload", http.StatusBadRequest)
+		return
+	}
+
+	logger.Error().Err(err).Msg("Unexpected error handling webhook request")
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+// DefaultResponseCallback responds with a 200 OK for handled events and a 202
+// Accepted status for all other events. By default, responses are empty.
+// Event handlers may send custom responses by calling the SetResponder
+// function before returning.
+func DefaultResponseCallback(w http.ResponseWriter, r *http.Request, event string, handled bool) {
+	if !handled && event != "ping" {
 		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	if res := GetResponder(r.Context()); res != nil {
+		res(w, r)
+	} else {
+		w.WriteHeader(http.StatusOK)
 	}
 }
 
-// DefaultErrorHandler logs errors and responds with a 500 status code.
-func DefaultErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	logger := zerolog.Ctx(r.Context())
-	logger.Error().Err(err).Msg("Unexpected error handling webhook request")
+type responderKey struct{}
 
-	msg := http.StatusText(http.StatusInternalServerError)
-	http.Error(w, msg, http.StatusInternalServerError)
+// SetResponder sets a function that sends a response to GitHub after event
+// processing completes. This function may only be called from event handler
+// functions invoked by the event dispatcher.
+//
+// Customizing individual handler responses should be rare. Applications that
+// want to modify the standard responses should consider registering a response
+// callback before using this function.
+func SetResponder(ctx context.Context, responder func(http.ResponseWriter, *http.Request)) {
+	r, ok := ctx.Value(responderKey{}).(*func(http.ResponseWriter, *http.Request))
+	if !ok || r == nil {
+		panic("SetResponder() must be called from an event handler invoked by the go-githubapp event dispatcher")
+	}
+	*r = responder
+}
+
+// GetResponder returns the response function that was set by an event handler.
+// If no response function exists, it returns nil. There is usually no reason
+// to call this outside of a response callback implementation.
+func GetResponder(ctx context.Context) func(http.ResponseWriter, *http.Request) {
+	r, ok := ctx.Value(responderKey{}).(*func(http.ResponseWriter, *http.Request))
+	if !ok || r == nil {
+		return nil
+	}
+	return *r
 }


### PR DESCRIPTION
All GitHub options and certain sensitive Bulldozer options can be
defined or overridden by environment variables. This also cleans up some
configuration-related content in the README and example file.

Fixes #126.