### PR TITLE
Build with Go 1.12.7, Godel 2.16.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     environment:
       TESTS_DIR: *results-dir
     docker:
-      - image: nmiyake/go:go-darwin-linux-1.11-t134
+      - image: circleci/golang:1.12.7
     steps:
       - checkout
       - *restore-godel-cache
@@ -49,7 +49,7 @@ jobs:
   dist:
     working_directory: /go/src/github.com/palantir/bulldozer
     docker:
-      - image: nmiyake/go:go-darwin-linux-1.11-docker-17.06.0-ce-bsdtar-unzip-t134
+      - image: circleci/golang:1.12.7
     steps:
       - checkout
       - setup_remote_docker

--- a/godel/config/check-plugin.yml
+++ b/godel/config/check-plugin.yml
@@ -3,9 +3,6 @@ checks:
     filters:
     - value: should have comment or be unexported
     - value: or a comment on this block
-  novendor:
-    filters:
-    - value: github.com/stretchr/objx
   errcheck:
     filters:
     - value: "Client\\.(Count|Gauge)"

--- a/godel/config/godel.properties
+++ b/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.10.0/godel-2.10.0.tgz
-distributionSHA256=503074b9177d05152f3225a4bd8fa1516182f9c35d88796fbbdc975637e06c45
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.16.0/godel-2.16.0.tgz
+distributionSHA256=48b946ee2d55c64794e7b03eb64da6ff061f34a77350622f2bb6786932788d1a

--- a/godelw
+++ b/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.10.0
-DARWIN_CHECKSUM=2f2d8a62e598f8a7784c92a0e6325251efa347d3550187a290ab72a9ed44917c
-LINUX_CHECKSUM=36f963816d8e06ab6f41711fd66a75706d3ddb376de4edef80e4fd09688c97f5
+VERSION=2.16.0
+DARWIN_CHECKSUM=71d997951823322fad1f87f6f634d5db0ab525c22ef5c7eb84091d822e6552a9
+LINUX_CHECKSUM=8bedeb60cc135304690799e6d375768bdc524d7d94a4bc5c1b9a89c86c5aa754
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {


### PR DESCRIPTION
Switch to the CircleCI-provided Docker images since they seem to be more
up-to-date than the internally-derived images we were using before.