### PR TITLE
fix(check_run): use full pr to retrieve event infos

### DIFF
--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -73,7 +73,7 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 		pullCtx := pull.NewGithubContext(client, fullPR)
 
 		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
-		if err := h.ProcessPullRequest(logger.WithContext(ctx), pullCtx, client, pr); err != nil {
+		if err := h.ProcessPullRequest(logger.WithContext(ctx), pullCtx, client, fullPR); err != nil {
 			logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")
 		}
 	}


### PR DESCRIPTION
As documented https://developer.github.com/v3/activity/events/types/#checkrunevent the check_run event pullrequests does not always contains base / repo / owner / login so as we already got the full pull request available in the code, we can use it to be sure to always have all the informations and be able to retrieve the bulldozer config file.

When the check_run event does not contains the pullrequest base / repo / owner / login info, then the bot cannot retrieve config info and failed to manage the event. Sometimes the check_run event is populated with pr / base / repo / owner / login, sometimes not. Still don't know why, we need to investigate more.

BTW, bulldozer should not use payload properties that are not documented to be present event if they are sometimes provided by github hooks. as documented here again: https://developer.github.com/v3/activity/events/types/#checkrunevent

Hope that helps

