### PR TITLE
PR merge can be triggered by push event

### DIFF
--- a/server/handler/push.go
+++ b/server/handler/push.go
@@ -80,6 +80,10 @@ func (h *Push) Handle(ctx context.Context, eventType, deliveryID string, payload
 		if err := h.UpdatePullRequest(logger.WithContext(ctx), pullCtx, client, pr, baseRef); err != nil {
 			logger.Error().Err(errors.WithStack(err)).Msg("Error updating pull request")
 		}
+
+		if err := h.ProcessPullRequest(ctx, pullCtx, client, pr); err != nil {
+			logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
In the following sequence of operations PR merge should be triggered by push
event:

- Alice submits a PR `alice-feature` which conflicts with `master`
- Bob submits a PR `bob-feature` that removes the conflict with `alice-feature`
  from `master`
- Bob's PR gets merged ("push" event)
- ...?

Fixes #147.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/148)
<!-- Reviewable:end -->
