### PR TITLE
Update: required status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ update:
   # bulldozer. It accepts the same keys as the blacklist in the "merge" block.
   blacklist:
     labels: ["Do Not Update"]
+
+  # "required_statuses" is a list of status contexts that must pass
+  # before bulldozer can update a pull request. This is useful if you want to
+  # update the branch only after PR is reviewed and deemed mergeable.
+  #
+  # Unlike with merges, only these statuses will be consulted, and the list
+  # of required statuses in branch protection rules will not be used.
+  required_statuses:
+    - "code-review/reviewable"
 ```
 
 ## FAQ

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -61,6 +61,9 @@ type SquashOptions struct {
 type UpdateConfig struct {
 	Whitelist Signals `yaml:"whitelist"`
 	Blacklist Signals `yaml:"blacklist"`
+
+	// Status checks to require for update
+	RequiredStatuses []string `yaml:"required_statuses"`
 }
 
 type Config struct {


### PR DESCRIPTION
This change mimics similar feature for merges.

Our use-case: we want PRs that have passed review to be updated to `master` and merged. We configure Bulldozer not to look at any labels, but merge once GH status checks allow to.

However update does not look at status checks, so it starts to frantically update the PR on every change of base branch.

This setting allows us to start updating after manual review has passed and merging after CI and manual review have passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/bulldozer/150)
<!-- Reviewable:end -->
