### PR TITLE
Add the default configuration file to the Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
       - image: circleci/golang:1.13.4-stretch
     steps:
       - checkout
-      - run: cp -r config docker/
       - setup_remote_docker
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - image: circleci/golang:1.13.4-stretch
     steps:
       - checkout
-      - run: cp config docker/
+      - run: cp -r config docker/
       - setup_remote_docker
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
       - image: circleci/golang:1.13.4-stretch
     steps:
       - checkout
+      - run: cp config docker/
       - setup_remote_docker
       - attach_workspace:
           at: .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM scratch
 STOPSIGNAL SIGINT
 
 # add the default configuration file
-COPY config/bulldozer.example.yml /secrets/bulldozer.yml
+COPY ../config/bulldozer.example.yml /secrets/bulldozer.yml
 
 # add static files
 COPY ca-certificates.crt /etc/ssl/certs/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,5 +8,8 @@ COPY ca-certificates.crt /etc/ssl/certs/
 # add application files
 COPY bulldozer /
 
+# add the default configuration file
+COPY config/bulldozer.example.yml /secrets/bulldozer.yml
+
 ENTRYPOINT ["build/linux-amd64/bulldozer"]
 CMD ["server", "--config", "/secrets/bulldozer.yml"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM scratch
 STOPSIGNAL SIGINT
 
 # add the default configuration file
-COPY ../config/bulldozer.example.yml /secrets/bulldozer.yml
+COPY config/bulldozer.example.yml /secrets/bulldozer.yml
 
 # add static files
 COPY ca-certificates.crt /etc/ssl/certs/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,14 @@ FROM scratch
 
 STOPSIGNAL SIGINT
 
+# add the default configuration file
+COPY config/bulldozer.example.yml /secrets/bulldozer.yml
+
 # add static files
 COPY ca-certificates.crt /etc/ssl/certs/
 
 # add application files
 COPY bulldozer /
-
-# add the default configuration file
-COPY config/bulldozer.example.yml /secrets/bulldozer.yml
 
 ENTRYPOINT ["build/linux-amd64/bulldozer"]
 CMD ["server", "--config", "/secrets/bulldozer.yml"]

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -28,6 +28,7 @@ products:
           script: |
             #!/usr/bin/env bash
             cp -R docker/* ${CONTEXT_DIR}
+            cp -R config ${CONTEXT_DIR}
           tag-templates:
             version: "{{Repository}}palantirtechnologies/bulldozer:{{Version}}"
             latest: "{{Repository}}palantirtechnologies/bulldozer:latest"


### PR DESCRIPTION
This will enable running the Docker image straight away (you can do all the necessary configuration by defining environment variables).

Without the file, the server refuses to start.
