### PR TITLE
Fix commit message modes after go-github changes

### DIFF
--- a/bulldozer/merge_test.go
+++ b/bulldozer/merge_test.go
@@ -117,12 +117,12 @@ func TestCalculateCommitMessage(t *testing.T) {
 		"emptyBody": {
 			PullContext: defaultPullContext,
 			Strategy:    EmptyBody,
-			Output:      "",
+			Output:      " ",
 		},
 		"summarizeCommits": {
 			PullContext: defaultPullContext,
 			Strategy:    SummarizeCommits,
-			Output:      "* The first commit message!\n* The second commit message!\n* The third commit message!\n",
+			Output:      "",
 		},
 		"pullRequestBody": {
 			PullContext: defaultPullContext,
@@ -141,7 +141,7 @@ func TestCalculateCommitMessage(t *testing.T) {
 			PullContext: defaultPullContext,
 			Strategy:    PullRequestBody,
 			Delimiter:   "~~",
-			Output:      "",
+			Output:      " ",
 		},
 	}
 


### PR DESCRIPTION
Passing an empty string as the commit message now selects the default behavior for the merge mode. Take advantage of this for summarization, but pass a non-empty whitespace string in the empty body case.

I need to test this out to make sure it works as expected, but I believe this fixes #192.