### PR TITLE
Accept wildcards in branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ merge:
     # Pull requests targeting any of these branches are added to the trigger.
     branches: ["develop"]
 
+    # Pull requests targeting branches matching any of these regular expressions are added to the trigger.
+    branch_patterns: ["feature/.*"]
+
   # "ignore" defines the set of pull request ignored by bulldozer. If the
   # section is missing, bulldozer considers all pull requests. It takes the
   # same keys as the "trigger" section.

--- a/bulldozer/signals.go
+++ b/bulldozer/signals.go
@@ -17,6 +17,7 @@ package bulldozer
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -113,7 +114,7 @@ func (s *Signals) Matches(ctx context.Context, pullCtx pull.Context, tag string)
 		logger.Debug().Msgf("No branches found to match against")
 	}
 	for _, signalBranch := range s.Branches {
-		if targetBranch == signalBranch {
+		if matched, _ := regexp.MatchString(signalBranch, targetBranch); matched {
 			return true, fmt.Sprintf("pull request target is a %s branch: %q", tag, signalBranch), nil
 		}
 	}

--- a/bulldozer/signals.go
+++ b/bulldozer/signals.go
@@ -31,6 +31,7 @@ type Signals struct {
 	Comments          []string `yaml:"comments"`
 	PRBodySubstrings  []string `yaml:"pr_body_substrings"`
 	Branches          []string `yaml:"branches"`
+	BranchPatterns    []string `yaml:"branch_patterns"`
 }
 
 func (s *Signals) Enabled() bool {
@@ -40,6 +41,7 @@ func (s *Signals) Enabled() bool {
 	size += len(s.Comments)
 	size += len(s.PRBodySubstrings)
 	size += len(s.Branches)
+	size += len(s.BranchPatterns)
 	return size > 0
 }
 
@@ -110,12 +112,17 @@ func (s *Signals) Matches(ctx context.Context, pullCtx pull.Context, tag string)
 	}
 
 	targetBranch, _ := pullCtx.Branches()
-	if len(s.Branches) == 0 {
-		logger.Debug().Msgf("No branches found to match against")
+	if len(s.Branches) == 0 || len(s.BranchPatterns) == 0 {
+		logger.Debug().Msgf("No branches or branch patterns found to match against")
 	}
 	for _, signalBranch := range s.Branches {
-		if matched, _ := regexp.MatchString(signalBranch, targetBranch); matched {
+		if targetBranch == signalBranch {
 			return true, fmt.Sprintf("pull request target is a %s branch: %q", tag, signalBranch), nil
+		}
+	}
+	for _, signalBranch := range s.BranchPatterns {
+		if matched, _ := regexp.MatchString(fmt.Sprintf("^%s$", signalBranch), targetBranch); matched {
+			return true, fmt.Sprintf("pull request target branch (%q) matches pattern: %q", targetBranch, signalBranch), nil
 		}
 	}
 

--- a/bulldozer/signals_test.go
+++ b/bulldozer/signals_test.go
@@ -31,7 +31,7 @@ func TestSignalsMatches(t *testing.T) {
 		Comments:          []string{"FULL_COMMENT_PLZ_MERGE"},
 		CommentSubstrings: []string{":+1:"},
 		PRBodySubstrings:  []string{"BODY_MERGE_PLZ"},
-		Branches:          []string{"develop"},
+		Branches:          []string{"develop", "test/*"},
 	}
 
 	ctx := context.Background()
@@ -104,6 +104,13 @@ func TestSignalsMatches(t *testing.T) {
 			},
 			Matches: true,
 			Reason:  `pull request target is a testlist branch: "develop"`,
+		},
+		"targetBranchMatchesBranchWildcard": {
+			PullContext: &pulltest.MockPullContext{
+				BranchBase: "test/test",
+			},
+			Matches: true,
+			Reason:  `pull request target is a testlist branch: "test/*"`,
 		},
 	}
 

--- a/bulldozer/signals_test.go
+++ b/bulldozer/signals_test.go
@@ -32,7 +32,7 @@ func TestSignalsMatches(t *testing.T) {
 		CommentSubstrings: []string{":+1:"},
 		PRBodySubstrings:  []string{"BODY_MERGE_PLZ"},
 		Branches:          []string{"develop"},
-		BranchPatterns:    []string{"test/.*"},
+		BranchPatterns:    []string{"test/.*", "^feature/.*$"},
 	}
 
 	ctx := context.Background()
@@ -126,6 +126,13 @@ func TestSignalsMatches(t *testing.T) {
 			},
 			Matches: false,
 			Reason:  `pull request does not match the testlist`,
+		},
+		"signalBranchContainsBoundaryMarkers": {
+			PullContext: &pulltest.MockPullContext{
+				BranchBase: "feature/awesomeFeature",
+			},
+			Matches: true,
+			Reason:  `pull request target branch ("feature/awesomeFeature") matches pattern: "^feature/.*$"`,
 		},
 	}
 

--- a/bulldozer/signals_test.go
+++ b/bulldozer/signals_test.go
@@ -31,7 +31,8 @@ func TestSignalsMatches(t *testing.T) {
 		Comments:          []string{"FULL_COMMENT_PLZ_MERGE"},
 		CommentSubstrings: []string{":+1:"},
 		PRBodySubstrings:  []string{"BODY_MERGE_PLZ"},
-		Branches:          []string{"develop", "test/*"},
+		Branches:          []string{"develop"},
+		BranchPatterns:    []string{"test/.*"},
 	}
 
 	ctx := context.Background()
@@ -107,10 +108,24 @@ func TestSignalsMatches(t *testing.T) {
 		},
 		"targetBranchMatchesBranchWildcard": {
 			PullContext: &pulltest.MockPullContext{
-				BranchBase: "test/test",
+				BranchBase: "test/v9.9.9",
 			},
 			Matches: true,
-			Reason:  `pull request target is a testlist branch: "test/*"`,
+			Reason:  `pull request target branch ("test/v9.9.9") matches pattern: "test/.*"`,
+		},
+		"targetBranchLikeSignalWithSpecialChars": {
+			PullContext: &pulltest.MockPullContext{
+				BranchBase: "testlist/v9.9.9",
+			},
+			Matches: false,
+			Reason:  `pull request does not match the testlist`,
+		},
+		"wildcardNoMatch": {
+			PullContext: &pulltest.MockPullContext{
+				BranchBase: "pretest/pretest",
+			},
+			Matches: false,
+			Reason:  `pull request does not match the testlist`,
 		},
 	}
 


### PR DESCRIPTION
Closes #199 

Enable selection of branches to watch for merges/updates using regex.


Signed-off-by: Andrey Zhereshchin <andrey.zhereshchin@ie.ibm.com>