### PR TITLE
Comment when Bulldozer fails merge PR

### DIFF
--- a/bulldozer/errors.go
+++ b/bulldozer/errors.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bulldozer
+
+type ErrComment struct {
+	s string
+}
+
+func (e ErrComment) Error() string {
+	return e.s
+}
+
+func newCommentError(text string) error {
+	return &ErrComment{text}
+}

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -152,7 +152,7 @@ func (m *PushRestrictionMerger) DeleteHead(ctx context.Context, pullCtx pull.Con
 
 // MergePR merges a pull request if all conditions are met. It logs any errors
 // that it encounters.
-func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConfig MergeConfig) string {
+func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConfig MergeConfig) error {
 	logger := zerolog.Ctx(ctx)
 
 	base, head := pullCtx.Branches()
@@ -183,14 +183,14 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 		message, err := calculateCommitMessage(ctx, pullCtx, *opt)
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to calculate commit message")
-			return ""
+			return nil
 		}
 		commitMsg.Message = message
 
 		title, err := calculateCommitTitle(ctx, pullCtx, *opt)
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to calculate commit title")
-			return ""
+			return nil
 		}
 		commitMsg.Title = title
 	}
@@ -207,7 +207,7 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 		attempts++
 		if attempts >= MaxPullRequestPollCount {
 			logger.Error().Msgf("Failed to merge pull request after %d attempts", attempts)
-			return reason
+			return errors.New(reason)
 		}
 		time.Sleep(4 * time.Second)
 	}
@@ -220,7 +220,7 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 		}
 	}
 
-	return reason
+	return errors.New(reason)
 }
 
 // attemptMerge attempts to merge a pull request, logging any errors and

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -66,29 +66,9 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 			return errors.Wrap(err, "unable to determine merge status")
 		}
 		if shouldMerge {
-			failureReason := bulldozer.MergePR(ctx, pullCtx, merger, config.Merge)
-			if failureReason != "" {
-				comments, err := pullCtx.Comments(ctx)
-				if err != nil {
-					logger.Error().Err(err).Msg("failed to list pull request comments")
-				}
-
-				// Only leave a comment if we're presenting new information to the user
-				// Otherwise we're just spamming folks instead of diligently merging PRs
-				shouldComment := true
-				for _, comment := range comments {
-					if strings.EqualFold(comment, failureReason) {
-						shouldComment = false
-					}
-				}
-
-				if shouldComment {
-					_, _, err := client.Issues.CreateComment(ctx, pullCtx.Owner(), pullCtx.Repo(), pullCtx.Number(), &github.IssueComment{
-						Body: github.String(failureReason),
-					})
-					if err != nil {
-						logger.Error().Err(err).Msg("unable to post failure comment")
-					}
+			if err := bulldozer.MergePR(ctx, pullCtx, merger, config.Merge); err != nil {
+				if err := addUniqueComment(ctx, pullCtx, client, err.Error()); err != nil {
+					logger.Error().Err(err).Msg("fail to post unique comment")
 				}
 			}
 		}
@@ -123,5 +103,31 @@ func (b *Base) UpdatePullRequest(ctx context.Context, pullCtx pull.Context, clie
 		}
 	}
 
+	return nil
+}
+
+func addUniqueComment(ctx context.Context, pullCtx pull.Context, client *github.Client, errorComment string) error {
+	comments, err := pullCtx.Comments(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to listed pull request comments")
+	}
+
+	// Only leave a comment if we're presenting new information to the user
+	// Otherwise we're just spamming folks instead of diligently merging PRs
+	shouldComment := true
+	for _, comment := range comments {
+		if strings.EqualFold(comment, errorComment) {
+			shouldComment = false
+		}
+	}
+
+	if shouldComment {
+		_, _, err := client.Issues.CreateComment(ctx, pullCtx.Owner(), pullCtx.Repo(), pullCtx.Number(), &github.IssueComment{
+			Body: github.String(errorComment),
+		})
+		if err != nil {
+			return errors.Wrapf(err, "unable to post failure comment")
+		}
+	}
 	return nil
 }

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -30,6 +30,7 @@ type Base struct {
 	githubapp.ClientCreator
 	bulldozer.ConfigFetcher
 
+	AppName                  string
 	PushRestrictionUserToken string
 }
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -67,8 +67,11 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 		}
 		if shouldMerge {
 			if err := bulldozer.MergePR(ctx, pullCtx, merger, config.Merge); err != nil {
-				if err := addUniqueComment(ctx, pullCtx, client, err.Error()); err != nil {
-					logger.Error().Err(err).Msg("fail to post unique comment")
+				logger.Error().Err(err).Msg("failed to merge pull request")
+				if _, ok := err.(*bulldozer.ErrComment); ok {
+					if err := addUniqueComment(ctx, pullCtx, client, err.Error()); err != nil {
+						logger.Error().Err(err).Msg("fail to post unique comment")
+					}
 				}
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/c2h5oh/datasize"
@@ -70,11 +71,22 @@ func New(c *Config) (*Server, error) {
 		return nil, errors.Wrap(err, "failed to initialize Github client creator")
 	}
 
+	client, err := clientCreator.NewAppClient()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get app client")
+	}
+
+	app, _, err := client.Apps.Get(context.Background(), "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get app context")
+	}
+
 	baseHandler := handler.Base{
 		ClientCreator: clientCreator,
 		ConfigFetcher: bulldozer.NewConfigFetcher(c.Options.ConfigurationPath, c.Options.ConfigurationV0Paths, c.Options.DefaultRepositoryConfig),
 
 		PushRestrictionUserToken: c.Options.PushRestrictionUserToken,
+		AppName:                  app.GetName(),
 	}
 
 	queueSize := c.Workers.QueueSize


### PR DESCRIPTION
Only leave a comment when bulldozer fails to merge a PR via the API, rather than speculatively reasoning about state before we attempt to merge. An alternative approach to #213

Resolves #195

