### PR TITLE
Allow server port to be set via environment variable

### DIFF
--- a/config/bulldozer.example.yml
+++ b/config/bulldozer.example.yml
@@ -1,10 +1,15 @@
 # Options for the http server
 server:
-  # The listen address and port
+  # The listen address. Can also be set by the BULLDOZER_ADDRESS environment
+  # variable.
   address: "0.0.0.0"
+  # The listen port. Can also be set by the BULLDOZER_PORT environment
+  # variable.
   port: 8080
   # Uncomment the "tls_config" block to enable HTTPS support in the server.
   # The cert and key files must be usable by net/http.ListenAndServeTLS().
+  # Cert and Key file can also be set by the BULLDOZER_TLS_CERT_FILE and
+  # BULLDOZER_TLS_KEY_FILE environment variables, respectively.
   # tls_config:
   #   cert_file: /path/to/server.pem
   #   key_file: /path/to/server.key

--- a/server/config.go
+++ b/server/config.go
@@ -67,6 +67,7 @@ func ParseConfig(bytes []byte) (*Config, error) {
 	}
 
 	c.Github.SetValuesFromEnv("")
+	c.Server.SetValuesFromEnv("BULLDOZER_")
 	if v, ok := os.LookupEnv("BULLDOZER_PUSH_RESTRICTION_USER_TOKEN"); ok {
 		c.Options.PushRestrictionUserToken = v
 	}


### PR DESCRIPTION
Thank you for this amazing tool!

Heroku expects the web process to dynamically set the listen port based on the PORT variable. This, in combination with
a [.profile](https://devcenter.heroku.com/articles/dynos#the-profile-file) to set `PORT=BULLDOZER_PORT`, will make it easier to run bulldozer in Heroku, as well as allowing other HTTP-related config to be set via environment variables.

https://devcenter.heroku.com/articles/container-registry-and-runtime#dockerfile-commands-and-runtime

This is my first time writing Go and I'm sure I didn't get everything exactly right. Please let me know what you'd like me to change here. And of course no worries if this feature cannot be accepted.