### PR TITLE
Allow additional Checks conclusions for required statuses

### DIFF
--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -209,6 +209,11 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 	if ghc.successStatuses == nil {
 		opts := &github.ListOptions{PerPage: 100}
 		var successStatuses []string
+		allowedCheckConclusions := map[string]bool{
+			"success": true,
+			"neutral": true,
+			"skipped": true,
+		}
 
 		for {
 			combinedStatus, res, err := ghc.client.Repositories.GetCombinedStatus(ctx, ghc.owner, ghc.repo, ghc.pr.GetHead().GetSHA(), opts)
@@ -236,7 +241,7 @@ func (ghc *GithubContext) CurrentSuccessStatuses(ctx context.Context) ([]string,
 			}
 
 			for _, s := range checkRuns.CheckRuns {
-				if s.GetConclusion() == "success" {
+				if allowedCheckConclusions[s.GetConclusion()] {
 					successStatuses = append(successStatuses, s.GetName())
 				}
 			}


### PR DESCRIPTION
Add `"neutral"` and `"skipped"` to the allowed [Checks](https://docs.github.com/en/rest/reference/checks) conclusions for meeting merge requirements. This aligns Bulldozer with default GitHub requirements for merging with branch protection required statuses.

Closes #222 