### PR TITLE
Allow server env var prefix to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,10 @@ We provide both a Docker container and a binary distribution of the server:
 
 A sample configuration file is provided at `config/bulldozer.example.yml`.
 Certain values may also be set by environment variables; these are noted in the
-comments in the sample configuration file.
+comments in the sample configuration file. By default, the environment
+variables for server values are prefixed with `BULLDOZER_` (e.g.
+`BULLDOZER_PORT`). This prefix can be overridden by setting the
+`BULLDOZER_ENV_PREFIX` environment variable.
 
 ### GitHub App Configuration
 

--- a/server/config.go
+++ b/server/config.go
@@ -27,6 +27,10 @@ import (
 	"github.com/palantir/bulldozer/bulldozer"
 )
 
+const (
+	DefaultEnvPrefix = "BULLDOZER_"
+)
+
 type Config struct {
 	Server  baseapp.HTTPConfig `yaml:"server"`
 	Github  githubapp.Config   `yaml:"github"`
@@ -67,8 +71,14 @@ func ParseConfig(bytes []byte) (*Config, error) {
 	}
 
 	c.Github.SetValuesFromEnv("")
-	c.Server.SetValuesFromEnv("BULLDOZER_")
-	if v, ok := os.LookupEnv("BULLDOZER_PUSH_RESTRICTION_USER_TOKEN"); ok {
+
+	envPrefix := DefaultEnvPrefix
+	if v, ok := os.LookupEnv("BULLDOZER_ENV_PREFIX"); ok {
+		envPrefix = v
+	}
+	c.Server.SetValuesFromEnv(envPrefix)
+
+	if v, ok := os.LookupEnv(envPrefix + "PUSH_RESTRICTION_USER_TOKEN"); ok {
 		c.Options.PushRestrictionUserToken = v
 	}
 


### PR DESCRIPTION
As suggested [here](https://github.com/palantir/bulldozer/pull/220#issuecomment-781764581), use a `BULLDOZER_ENV_PREFIX` environment variable to override the prefix for server configuration values. This makes it possible to run the Docker container on Heroku, where it is expected that the container will listen on the port specified in the `PORT` environment variable.