### PR TITLE
Fix prematurely merging PR after update

### DIFF
--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -82,21 +82,24 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 	return nil
 }
 
-func (b *Base) UpdatePullRequest(ctx context.Context, pullCtx pull.Context, client *github.Client, config *bulldozer.Config, pr *github.PullRequest, baseRef string) error {
+func (b *Base) UpdatePullRequest(ctx context.Context, pullCtx pull.Context, client *github.Client, config *bulldozer.Config, pr *github.PullRequest, baseRef string) (bool, error) {
 	logger := zerolog.Ctx(ctx)
 
 	if config == nil {
 		logger.Debug().Msg("UpdatePullRequest: returning immediately due to nil config")
-		return nil
+		return false, nil
 	}
 
 	shouldUpdate, err := bulldozer.ShouldUpdatePR(ctx, pullCtx, config.Update)
 	if err != nil {
-		return errors.Wrap(err, "unable to determine update status")
-	}
-	if shouldUpdate {
-		bulldozer.UpdatePR(ctx, pullCtx, client, config.Update, baseRef)
+		return false, errors.Wrap(err, "unable to determine update status")
 	}
 
-	return nil
+	didUpdatePR := false
+
+	if shouldUpdate {
+		didUpdatePR = bulldozer.UpdatePR(ctx, pullCtx, client, config.Update, baseRef)
+	}
+
+	return didUpdatePR, nil
 }

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -71,8 +71,13 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 
 	if event.GetAction() == "labeled" || event.GetAction() == "opened" {
 		base, _ := pullCtx.Branches()
-		if err := h.UpdatePullRequest(logger.WithContext(ctx), pullCtx, client, config, pr, base); err != nil {
+		didUpdatePR, err := h.UpdatePullRequest(logger.WithContext(ctx), pullCtx, client, config, pr, base)
+		if err != nil {
 			logger.Error().Err(errors.WithStack(err)).Msg("Error updating pull request")
+		}
+
+		if didUpdatePR {
+			return nil
 		}
 	}
 

--- a/server/handler/push.go
+++ b/server/handler/push.go
@@ -82,7 +82,7 @@ func (h *Push) Handle(ctx context.Context, eventType, deliveryID string, payload
 		}
 
 		logger.Debug().Msgf("checking status for updated sha %s", baseRef)
-		if err := h.UpdatePullRequest(logger.WithContext(ctx), pullCtx, client, config, pr, baseRef); err != nil {
+		if _, err := h.UpdatePullRequest(logger.WithContext(ctx), pullCtx, client, config, pr, baseRef); err != nil {
 			logger.Error().Err(errors.WithStack(err)).Msg("Error updating pull request")
 		}
 	}


### PR DESCRIPTION
After my changes in https://github.com/palantir/bulldozer/pull/235, I noticed that sometimes a PR is updated and then merged as part of the same webhook request, before the required statuses are fulfilled. This is because bulldozer was still using the stale statuses from before the update was performed.

This change skips the merge if the PR was updated to avoid using the stale PR status.