### PR TITLE
Allow ignoring Draft PRs from updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ update:
   # bulldozer. It accepts the same keys as the ignore in the "merge" block.
   ignore:
     labels: ["Do Not Update"]
+
+  # If true, bulldozer will ignore updating draft pull requests, unless they
+  # explicitly match a configured trigger condition.
+  ignore_draft_pr: false
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ update:
 
   # If true, bulldozer will ignore updating draft pull requests, unless they
   # explicitly match a configured trigger condition.
-  ignore_draft_pr: false
+  ignore_drafts: false
 ```
 
 ## FAQ

--- a/bulldozer/config_fetcher_test.go
+++ b/bulldozer/config_fetcher_test.go
@@ -59,7 +59,7 @@ update:
 			Labels:            []string{"do not merge"},
 			CommentSubstrings: []string{"==DO_NOT_MERGE=="},
 		}, actual.Merge.Ignore)
-		assert.Equal(t, actual.Update.IgnoreDrafts, true)
+		assert.Equal(t, *actual.Update.IgnoreDrafts, true)
 	})
 
 	t.Run("parseExisting", func(t *testing.T) {
@@ -106,6 +106,7 @@ update:
 		assert.Equal(t, Signals{
 			Labels: []string{"do not update"},
 		}, actual.Update.Ignore)
+		assert.Nil(t, actual.Update.IgnoreDrafts)
 	})
 
 	t.Run("ignoresOldConfig", func(t *testing.T) {

--- a/bulldozer/config_fetcher_test.go
+++ b/bulldozer/config_fetcher_test.go
@@ -46,6 +46,7 @@ update:
     labels: ["wip", "update me"]
   ignore:
     labels: ["do not update"]
+  ignore_draft_pr: true
 `
 
 		actual, err := cf.unmarshalConfig([]byte(config))
@@ -58,6 +59,7 @@ update:
 			Labels:            []string{"do not merge"},
 			CommentSubstrings: []string{"==DO_NOT_MERGE=="},
 		}, actual.Merge.Ignore)
+		assert.Equal(t, actual.Update.IgnoreDraftPR, true)
 	})
 
 	t.Run("parseExisting", func(t *testing.T) {

--- a/bulldozer/config_fetcher_test.go
+++ b/bulldozer/config_fetcher_test.go
@@ -46,7 +46,7 @@ update:
     labels: ["wip", "update me"]
   ignore:
     labels: ["do not update"]
-  ignore_draft_pr: true
+  ignore_drafts: true
 `
 
 		actual, err := cf.unmarshalConfig([]byte(config))
@@ -59,7 +59,7 @@ update:
 			Labels:            []string{"do not merge"},
 			CommentSubstrings: []string{"==DO_NOT_MERGE=="},
 		}, actual.Merge.Ignore)
-		assert.Equal(t, actual.Update.IgnoreDraftPR, true)
+		assert.Equal(t, actual.Update.IgnoreDrafts, true)
 	})
 
 	t.Run("parseExisting", func(t *testing.T) {

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -68,6 +68,8 @@ type UpdateConfig struct {
 	Trigger Signals `yaml:"trigger"`
 	Ignore  Signals `yaml:"ignore"`
 
+	IgnoreDraftPR bool `yaml:"ignore_draft_pr"`
+
 	// Blacklist and Whitelist are legacy options that will be disabled in a future v2 format
 	Blacklist Signals `yaml:"blacklist"`
 	Whitelist Signals `yaml:"whitelist"`

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -68,7 +68,7 @@ type UpdateConfig struct {
 	Trigger Signals `yaml:"trigger"`
 	Ignore  Signals `yaml:"ignore"`
 
-	IgnoreDraftPR bool `yaml:"ignore_draft_pr"`
+	IgnoreDrafts bool `yaml:"ignore_drafts"`
 
 	// Blacklist and Whitelist are legacy options that will be disabled in a future v2 format
 	Blacklist Signals `yaml:"blacklist"`

--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -68,7 +68,7 @@ type UpdateConfig struct {
 	Trigger Signals `yaml:"trigger"`
 	Ignore  Signals `yaml:"ignore"`
 
-	IgnoreDrafts bool `yaml:"ignore_drafts"`
+	IgnoreDrafts *bool `yaml:"ignore_drafts"`
 
 	// Blacklist and Whitelist are legacy options that will be disabled in a future v2 format
 	Blacklist Signals `yaml:"blacklist"`

--- a/bulldozer/update.go
+++ b/bulldozer/update.go
@@ -55,7 +55,7 @@ func ShouldUpdatePR(ctx context.Context, pullCtx pull.Context, updateConfig Upda
 		return true, nil
 	}
 
-	if updateConfig.IgnoreDraftPR && pullCtx.IsDraft(ctx) {
+	if updateConfig.IgnoreDrafts && pullCtx.IsDraft(ctx) {
 		logger.Debug().Msgf("%s is deemed not updateable because PR is in a draft state", pullCtx.Locator())
 		return false, nil
 	}

--- a/bulldozer/update.go
+++ b/bulldozer/update.go
@@ -52,6 +52,12 @@ func ShouldUpdatePR(ctx context.Context, pullCtx pull.Context, updateConfig Upda
 		}
 
 		logger.Debug().Msgf("%s is triggered because triggering is enabled and %s", pullCtx.Locator(), reason)
+		return true, nil
+	}
+
+	if updateConfig.IgnoreDraftPR && pullCtx.IsDraft(ctx) {
+		logger.Debug().Msgf("%s is deemed not updateable because PR is in a draft state", pullCtx.Locator())
+		return false, nil
 	}
 
 	return true, nil

--- a/bulldozer/update.go
+++ b/bulldozer/update.go
@@ -26,7 +26,7 @@ import (
 func ShouldUpdatePR(ctx context.Context, pullCtx pull.Context, updateConfig UpdateConfig) (bool, error) {
 	logger := zerolog.Ctx(ctx)
 
-	if !updateConfig.Ignore.Enabled() && !updateConfig.Trigger.Enabled() {
+	if !updateConfig.Ignore.Enabled() && !updateConfig.Trigger.Enabled() && updateConfig.IgnoreDrafts == nil {
 		return false, nil
 	}
 
@@ -55,7 +55,7 @@ func ShouldUpdatePR(ctx context.Context, pullCtx pull.Context, updateConfig Upda
 		return true, nil
 	}
 
-	if updateConfig.IgnoreDrafts && pullCtx.IsDraft(ctx) {
+	if updateConfig.IgnoreDrafts != nil && *updateConfig.IgnoreDrafts && pullCtx.IsDraft(ctx) {
 		logger.Debug().Msgf("%s is deemed not updateable because PR is in a draft state", pullCtx.Locator())
 		return false, nil
 	}

--- a/bulldozer/update_test.go
+++ b/bulldozer/update_test.go
@@ -17,6 +17,7 @@ package bulldozer
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/palantir/bulldozer/pull"
@@ -31,70 +32,91 @@ func TestShouldUpdatePR(t *testing.T) {
 		ignored         bool
 		triggerEnabled  bool
 		triggered       bool
-		ignoreDrafts    bool
+		ignoreDrafts    *bool
 		isDraft         bool
 		expectingUpdate bool
 	}{
-		{false, false, false, false, false, false, false},
-		{false, false, false, true, false, false, false},
-		{false, false, true, false, false, false, false},
-		{false, false, true, true, false, false, true},
-		{false, true, false, false, false, false, false},
-		{false, true, false, true, false, false, false},
-		{false, true, true, false, false, false, false},
-		{false, true, true, true, false, false, true},
-		{true, false, false, false, false, false, true},
-		{true, false, false, true, false, false, true},
-		{true, false, true, false, false, false, false},
-		{true, false, true, true, false, false, true},
-		{true, true, false, false, false, false, false},
-		{true, true, false, true, false, false, false},
-		{true, true, true, false, false, false, false},
-		{true, true, true, true, false, false, false},
-		// Test Draft PRs are still handled correctly when ignoring them is not enabled
-		{false, false, false, false, false, true, false},
-		{false, false, false, true, false, true, false},
-		{false, false, true, false, false, true, false},
-		{false, false, true, true, false, true, true},
-		{false, true, false, false, false, true, false},
-		{false, true, false, true, false, true, false},
-		{false, true, true, false, false, true, false},
-		{false, true, true, true, false, true, true},
-		{true, false, false, false, false, true, true},
-		{true, false, false, true, false, true, true},
-		{true, false, true, false, false, true, false},
-		{true, false, true, true, false, true, true},
-		{true, true, false, false, false, true, false},
-		{true, true, false, true, false, true, false},
-		{true, true, true, false, false, true, false},
-		{true, true, true, true, false, true, false},
+		{false, false, false, false, nil, false, false},
+		{false, false, false, true, nil, false, false},
+		{false, false, true, false, nil, false, false},
+		{false, false, true, true, nil, false, true},
+		{false, true, false, false, nil, false, false},
+		{false, true, false, true, nil, false, false},
+		{false, true, true, false, nil, false, false},
+		{false, true, true, true, nil, false, true},
+		{true, false, false, false, nil, false, true},
+		{true, false, false, true, nil, false, true},
+		{true, false, true, false, nil, false, false},
+		{true, false, true, true, nil, false, true},
+		{true, true, false, false, nil, false, false},
+		{true, true, false, true, nil, false, false},
+		{true, true, true, false, nil, false, false},
+		{true, true, true, true, nil, false, false},
+		// Test Draft PRs are still handled correctly when ignoring them is not configured
+		{false, false, false, false, nil, true, false},
+		{false, false, false, true, nil, true, false},
+		{false, false, true, false, nil, true, false},
+		{false, false, true, true, nil, true, true},
+		{false, true, false, false, nil, true, false},
+		{false, true, false, true, nil, true, false},
+		{false, true, true, false, nil, true, false},
+		{false, true, true, true, nil, true, true},
+		{true, false, false, false, nil, true, true},
+		{true, false, false, true, nil, true, true},
+		{true, false, true, false, nil, true, false},
+		{true, false, true, true, nil, true, true},
+		{true, true, false, false, nil, true, false},
+		{true, true, false, true, nil, true, false},
+		{true, true, true, false, nil, true, false},
+		{true, true, true, true, nil, true, false},
+		// Test Draft PRs are handled correctly when ignoring them is not enabled
+		{false, false, false, false, boolVal(false), true, true}, // All updates enabled
+		{false, false, false, true, boolVal(false), true, true},  // All updates enabled
+		{false, false, true, false, boolVal(false), true, false},
+		{false, false, true, true, boolVal(false), true, true},
+		{false, true, false, false, boolVal(false), true, true}, // All updates enabled
+		{false, true, false, true, boolVal(false), true, true},  // All updates enabled
+		{false, true, true, false, boolVal(false), true, false},
+		{false, true, true, true, boolVal(false), true, true},
+		{true, false, false, false, boolVal(false), true, true},
+		{true, false, false, true, boolVal(false), true, true},
+		{true, false, true, false, boolVal(false), true, false},
+		{true, false, true, true, boolVal(false), true, true},
+		{true, true, false, false, boolVal(false), true, false},
+		{true, true, false, true, boolVal(false), true, false},
+		{true, true, true, false, boolVal(false), true, false},
+		{true, true, true, true, boolVal(false), true, false},
 		// Test Draft PRs are handled correctly when ignoring them is enabled
-		{false, false, false, false, true, true, false},
-		{true, true, false, false, true, true, false},
-		{true, false, false, false, true, true, false},
-		{false, true, false, false, true, true, false},
-		{false, false, true, true, true, true, true},
-		{false, false, true, false, true, true, false},
-		{false, false, false, true, true, true, false},
-		{true, true, true, true, true, true, false},
-		{true, false, true, true, true, true, true},
-		{false, true, true, true, true, true, true},
-		{true, true, false, true, true, true, false},
-		{true, true, true, false, true, true, false},
-		{true, false, true, false, true, true, false},
-		{false, true, false, true, true, true, false},
+		{false, false, false, false, boolVal(true), true, false},
+		{true, true, false, false, boolVal(true), true, false},
+		{true, false, false, false, boolVal(true), true, false},
+		{false, true, false, false, boolVal(true), true, false},
+		{false, false, true, true, boolVal(true), true, true},
+		{false, false, true, false, boolVal(true), true, false},
+		{false, false, false, true, boolVal(true), true, false},
+		{true, true, true, true, boolVal(true), true, false},
+		{true, false, true, true, boolVal(true), true, true},
+		{false, true, true, true, boolVal(true), true, true},
+		{true, true, false, true, boolVal(true), true, false},
+		{true, true, true, false, boolVal(true), true, false},
+		{true, false, true, false, boolVal(true), true, false},
+		{false, true, false, true, boolVal(true), true, false},
 	}
 
 	for ndx, testCase := range testMatrix {
 		pullCtx, updateConfig := generateUpdateTestCase(testCase.ignoreEnabled, testCase.ignored, testCase.triggerEnabled, testCase.triggered, testCase.ignoreDrafts, testCase.isDraft)
 		updating, err := ShouldUpdatePR(ctx, pullCtx, updateConfig)
 		require.NoError(t, err)
-		msg := fmt.Sprintf("case %d - ignoreEnabled=%t ignored=%t triggerEnabled=%t triggered=%t ignoreDrafts=%t isDraft=%t -> doUpdate=%t",
-			ndx, testCase.ignoreEnabled, testCase.ignored, testCase.triggerEnabled, testCase.triggered, testCase.ignoreDrafts, testCase.isDraft, testCase.expectingUpdate)
+		ignoreDraftsPrintVal := "nil"
+		if testCase.ignoreDrafts != nil {
+			ignoreDraftsPrintVal = strconv.FormatBool(*testCase.ignoreDrafts)
+		}
+		msg := fmt.Sprintf("case %d - ignoreEnabled=%t ignored=%t triggerEnabled=%t triggered=%t ignoreDrafts=%v isDraft=%t -> doUpdate=%t",
+			ndx, testCase.ignoreEnabled, testCase.ignored, testCase.triggerEnabled, testCase.triggered, ignoreDraftsPrintVal, testCase.isDraft, testCase.expectingUpdate)
 		require.Equal(t, testCase.expectingUpdate, updating, msg)
 	}
 }
-func generateUpdateTestCase(ignorable bool, ignored bool, triggerable bool, triggered bool, ignoreDrafts bool, isDraft bool) (pull.Context, UpdateConfig) {
+func generateUpdateTestCase(ignorable bool, ignored bool, triggerable bool, triggered bool, ignoreDrafts *bool, isDraft bool) (pull.Context, UpdateConfig) {
 	updateConfig := UpdateConfig{
 		IgnoreDrafts: ignoreDrafts,
 	}
@@ -119,4 +141,8 @@ func generateUpdateTestCase(ignorable bool, ignored bool, triggerable bool, trig
 	}
 
 	return &pullCtx, updateConfig
+}
+
+func boolVal(b bool) *bool {
+	return &b
 }

--- a/bulldozer/update_test.go
+++ b/bulldozer/update_test.go
@@ -31,8 +31,8 @@ func TestShouldUpdatePR(t *testing.T) {
 		ignored         bool
 		triggerEnabled  bool
 		triggered       bool
-		ignoreDraftPR   bool
-		isDraftPR       bool
+		ignoreDrafts    bool
+		isDraft         bool
 		expectingUpdate bool
 	}{
 		{false, false, false, false, false, false, false},
@@ -86,20 +86,20 @@ func TestShouldUpdatePR(t *testing.T) {
 	}
 
 	for ndx, testCase := range testMatrix {
-		pullCtx, updateConfig := generateUpdateTestCase(testCase.ignoreEnabled, testCase.ignored, testCase.triggerEnabled, testCase.triggered, testCase.ignoreDraftPR, testCase.isDraftPR)
+		pullCtx, updateConfig := generateUpdateTestCase(testCase.ignoreEnabled, testCase.ignored, testCase.triggerEnabled, testCase.triggered, testCase.ignoreDrafts, testCase.isDraft)
 		updating, err := ShouldUpdatePR(ctx, pullCtx, updateConfig)
 		require.NoError(t, err)
-		msg := fmt.Sprintf("case %d - ignoreEnabled=%t ignored=%t triggerEnabled=%t triggered=%t ignoreDraftPR=%t isDraftPR=%t -> doUpdate=%t",
-			ndx, testCase.ignoreEnabled, testCase.ignored, testCase.triggerEnabled, testCase.triggered, testCase.ignoreDraftPR, testCase.isDraftPR, testCase.expectingUpdate)
+		msg := fmt.Sprintf("case %d - ignoreEnabled=%t ignored=%t triggerEnabled=%t triggered=%t ignoreDrafts=%t isDraft=%t -> doUpdate=%t",
+			ndx, testCase.ignoreEnabled, testCase.ignored, testCase.triggerEnabled, testCase.triggered, testCase.ignoreDrafts, testCase.isDraft, testCase.expectingUpdate)
 		require.Equal(t, testCase.expectingUpdate, updating, msg)
 	}
 }
-func generateUpdateTestCase(ignorable bool, ignored bool, triggerable bool, triggered bool, ignoreDraftPR bool, isDraftPR bool) (pull.Context, UpdateConfig) {
+func generateUpdateTestCase(ignorable bool, ignored bool, triggerable bool, triggered bool, ignoreDrafts bool, isDraft bool) (pull.Context, UpdateConfig) {
 	updateConfig := UpdateConfig{
-		IgnoreDraftPR: ignoreDraftPR,
+		IgnoreDrafts: ignoreDrafts,
 	}
 	pullCtx := pulltest.MockPullContext{
-		IsDraftValue: isDraftPR,
+		IsDraftValue: isDraft,
 	}
 
 	if ignorable {

--- a/pull/context.go
+++ b/pull/context.go
@@ -81,6 +81,9 @@ type Context interface {
 	// IsTargeted returns true if the head branch of this pull request is the
 	// target branch of other open PRs on the repository.
 	IsTargeted(ctx context.Context) (bool, error)
+
+	// IsDraft returns true if the PR is in a draft state.
+	IsDraft(ctx context.Context) bool
 }
 
 type MergeState struct {

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -290,7 +290,7 @@ func (ghc *GithubContext) IsTargeted(ctx context.Context) (bool, error) {
 }
 
 func (ghc *GithubContext) IsDraft(ctx context.Context) bool {
-	return *ghc.pr.Draft
+	return ghc.pr.GetDraft()
 }
 
 // type assertion

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -289,5 +289,9 @@ func (ghc *GithubContext) IsTargeted(ctx context.Context) (bool, error) {
 	return len(prs) > 0, nil
 }
 
+func (ghc *GithubContext) IsDraft(ctx context.Context) bool {
+	return *ghc.pr.Draft
+}
+
 // type assertion
 var _ Context = &GithubContext{}

--- a/pull/pulltest/mock_context.go
+++ b/pull/pulltest/mock_context.go
@@ -57,6 +57,8 @@ type MockPullContext struct {
 
 	IsTargetedValue    bool
 	IsTargetedErrValue error
+
+	IsDraftValue bool
 }
 
 func (c *MockPullContext) Owner() string {
@@ -124,6 +126,10 @@ func (c *MockPullContext) Labels(ctx context.Context) ([]string, error) {
 
 func (c *MockPullContext) IsTargeted(ctx context.Context) (bool, error) {
 	return c.IsTargetedValue, c.IsTargetedErrValue
+}
+
+func (c *MockPullContext) IsDraft(ctx context.Context) bool {
+	return c.IsDraftValue
 }
 
 // type assertion


### PR DESCRIPTION
Allow ignoring Draft PRs from automated Bulldozer update merge commits. Closes #191.

Features:
- Continue updating Draft PRs by default (current functionality)
- New `ignore_draft_pr` config under `update` block to ignore Draft PRs from updating
- Allow updating Draft PRs if `ignore_draft_pr` is enabled *but* the PR matches a configured `trigger` condition

I built and manually tested this in our environment (GitHub Enterprise 2.22) and it worked as expected.