### PR TITLE
Fetch configuration once when updating PRs

### DIFF
--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -32,10 +32,17 @@ type Base struct {
 	PushRestrictionUserToken string
 }
 
-func (b *Base) FetchConfig(ctx context.Context, client *github.Client, pr *github.PullRequest) (*bulldozer.Config, error) {
+func (b *Base) FetchConfigForPR(ctx context.Context, client *github.Client, pr *github.PullRequest) (*bulldozer.Config, error) {
+	owner := pr.GetBase().GetRepo().GetOwner().GetLogin()
+	repo := pr.GetBase().GetRepo().GetName()
+	ref := pr.GetBase().GetRef()
+	return b.FetchConfig(ctx, client, owner, repo, ref)
+}
+
+func (b *Base) FetchConfig(ctx context.Context, client *github.Client, owner, repo, ref string) (*bulldozer.Config, error) {
 	logger := zerolog.Ctx(ctx)
 
-	fc := b.ConfigFetcher.ConfigForPR(ctx, client, pr)
+	fc := b.ConfigFetcher.Config(ctx, client, owner, repo, ref)
 	switch {
 	case fc.LoadError != nil:
 		return nil, errors.Wrapf(fc.LoadError, "failed to load configuration: %s: %s", fc.Source, fc.Path)

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -73,7 +73,7 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 		}
 		pullCtx := pull.NewGithubContext(client, fullPR)
 
-		config, err := h.FetchConfig(ctx, client, fullPR)
+		config, err := h.FetchConfigForPR(ctx, client, fullPR)
 		if err != nil {
 			return err
 		}

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -44,12 +44,8 @@ func NewConfigFetcher(loader *appconfig.Loader, defaultConfig *bulldozer.Config)
 	}
 }
 
-func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, client *github.Client, pr *github.PullRequest) FetchedConfig {
+func (cf *ConfigFetcher) Config(ctx context.Context, client *github.Client, owner, repo, ref string) FetchedConfig {
 	logger := zerolog.Ctx(ctx)
-
-	owner := pr.GetBase().GetRepo().GetOwner().GetLogin()
-	repo := pr.GetBase().GetRepo().GetName()
-	ref := pr.GetBase().GetRef()
 
 	c, err := cf.loader.LoadConfig(ctx, client, owner, repo, ref)
 	fc := FetchedConfig{

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -56,7 +56,7 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	}
 	pullCtx := pull.NewGithubContext(client, pr)
 
-	config, err := h.FetchConfig(ctx, client, pr)
+	config, err := h.FetchConfigForPR(ctx, client, pr)
 	if err != nil {
 		return err
 	}

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -63,7 +63,7 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	}
 	pullCtx := pull.NewGithubContext(client, pr)
 
-	config, err := h.FetchConfig(ctx, client, pr)
+	config, err := h.FetchConfigForPR(ctx, client, pr)
 	if err != nil {
 		return err
 	}

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -56,7 +56,7 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 	}
 	pullCtx := pull.NewGithubContext(client, pr)
 
-	config, err := h.FetchConfig(ctx, client, pr)
+	config, err := h.FetchConfigForPR(ctx, client, pr)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch configuration")
 	}

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -67,7 +67,7 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 	for _, pr := range prs {
 		pullCtx := pull.NewGithubContext(client, pr)
 		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
-		config, err := h.FetchConfig(ctx, client, pr)
+		config, err := h.FetchConfigForPR(ctx, client, pr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, we fetched the same configuration file for every PR that might be updated. This was a lot of redundant requests, especially if the repository uses remote configuration.

While I don't think this is the primary problem leading to rate limits, it should reduce the number of requests observed in #276.