### PR TITLE
Add logging for additional webhook events

### DIFF
--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -45,7 +45,7 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, repo, number)
 
-	logger.Debug().Msgf("received issue_comment %s event", event.GetAction())
+	logger.Debug().Msgf("Received issue_comment %s event", event.GetAction())
 
 	client, err := h.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -45,6 +45,8 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, repo, number)
 
+	logger.Debug().Msgf("received issue_comment %s event", event.GetAction())
+
 	client, err := h.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {
 		return errors.Wrap(err, "failed to instantiate github client")

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -45,7 +45,7 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, repo, number)
 
-	logger.Debug().Msgf("received pull_request %s event", event.GetAction())
+	logger.Debug().Msgf("Received pull_request %s event", event.GetAction())
 
 	if event.GetAction() == "closed" {
 		logger.Debug().Msg("Doing nothing since pull request is closed")

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -45,6 +45,8 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, repo, number)
 
+	logger.Debug().Msgf("received pull_request_review %s event", event.GetAction())
+
 	client, err := h.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {
 		return errors.Wrap(err, "failed to instantiate github client")

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -45,7 +45,7 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, repo, number)
 
-	logger.Debug().Msgf("received pull_request_review %s event", event.GetAction())
+	logger.Debug().Msgf("Received pull_request_review %s event", event.GetAction())
 
 	client, err := h.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -47,7 +47,7 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
 
-	logger.Debug().Msgf("Received status event for %s with state %s", checkName, checkState)
+	logger.Debug().Msgf("Received status %s event from %s", checkState, checkName)
 
 	if checkState != "success" {
 		logger.Debug().Msgf("Doing nothing since context state for %q was %q", event.GetContext(), event.GetState())

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -39,12 +39,17 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 	}
 
 	repo := event.GetRepo()
+	checkName := event.GetName()
+	checkState := event.GetState()
+
 	owner := repo.GetOwner().GetLogin()
 	repoName := repo.GetName()
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
 
-	if event.GetState() != "success" {
+	logger.Debug().Msgf("Received status event for %s with state %s", checkName, checkState)
+
+	if checkState != "success" {
 		logger.Debug().Msgf("Doing nothing since context state for %q was %q", event.GetContext(), event.GetState())
 		return nil
 	}


### PR DESCRIPTION
Currently only the `push` and `pull_request` events have debug logging when a webhook is received. This is helpful for determining the trigger for bulldozer evaluation when those events occur. This PR includes similar logging for `status`, `issue_comment`, and `pull_reuqest_review` events.