### PR TITLE
Add `auto_merge` trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ merge:
     # Pull requests targeting branches matching any of these regular expressions are added to the trigger.
     branch_patterns: ["feature/.*"]
 
+    # Pull requests with auto merge enabled are added to the trigger.
+    auto_merge: true
+
   # "ignore" defines the set of pull request ignored by bulldozer. If the
   # section is missing, bulldozer considers all pull requests. It takes the
   # same keys as the "trigger" section.

--- a/bulldozer/signals_test.go
+++ b/bulldozer/signals_test.go
@@ -32,6 +32,7 @@ func TestSignalsMatchesAny(t *testing.T) {
 		PRBodySubstrings:  []string{"BODY_MERGE_PLZ"},
 		Branches:          []string{"develop"},
 		BranchPatterns:    []string{"test/.*", "^feature/.*$"},
+		AutoMerge:         true,
 	}
 
 	ctx := context.Background()
@@ -132,6 +133,13 @@ func TestSignalsMatchesAny(t *testing.T) {
 			},
 			Matches: true,
 			Reason:  `pull request target branch ("feature/awesomeFeature") matches pattern: "^feature/.*$"`,
+		},
+		"autoMergeMatch": {
+			PullContext: &pulltest.MockPullContext{
+				AutoMergeValue: true,
+			},
+			Matches: true,
+			Reason:  "pull request is configured to auto merge",
 		},
 	}
 
@@ -263,6 +271,7 @@ func TestSignalsMatchesAll(t *testing.T) {
 		Branches:          []string{"test/v9.9.9", "other"},
 		BranchPatterns:    []string{"test/.*", "^feature/.*$"},
 		MaxCommits:        2,
+		AutoMerge:         true,
 	}
 
 	ctx := context.Background()
@@ -282,6 +291,7 @@ func TestSignalsMatchesAll(t *testing.T) {
 					{SHA: "1", Message: "commit 1"},
 					{SHA: "2", Message: "commit 2"},
 				},
+				AutoMergeValue: true,
 			},
 			Matches: true,
 			Reason:  `pull request matches all testlist signals`,
@@ -296,6 +306,7 @@ func TestSignalsMatchesAll(t *testing.T) {
 					{SHA: "1", Message: "commit 1"},
 					{SHA: "2", Message: "commit 2"},
 				},
+				AutoMergeValue: false,
 			},
 			Matches: false,
 			Reason:  `pull request does not match all testlist signals`,

--- a/pull/context.go
+++ b/pull/context.go
@@ -84,6 +84,9 @@ type Context interface {
 
 	// IsDraft returns true if the PR is in a draft state.
 	IsDraft(ctx context.Context) bool
+
+	// AutoMerge returns true if the PR is configured to be automatically merged.
+	AutoMerge(ctx context.Context) bool
 }
 
 type MergeState struct {

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -293,5 +293,11 @@ func (ghc *GithubContext) IsDraft(ctx context.Context) bool {
 	return ghc.pr.GetDraft()
 }
 
+func (ghc *GithubContext) AutoMerge(ctx context.Context) bool {
+	autoMerge := ghc.pr.GetAutoMerge()
+
+	return autoMerge != nil
+}
+
 // type assertion
 var _ Context = &GithubContext{}

--- a/pull/pulltest/mock_context.go
+++ b/pull/pulltest/mock_context.go
@@ -58,7 +58,8 @@ type MockPullContext struct {
 	IsTargetedValue    bool
 	IsTargetedErrValue error
 
-	IsDraftValue bool
+	IsDraftValue   bool
+	AutoMergeValue bool
 }
 
 func (c *MockPullContext) Owner() string {
@@ -130,6 +131,10 @@ func (c *MockPullContext) IsTargeted(ctx context.Context) (bool, error) {
 
 func (c *MockPullContext) IsDraft(ctx context.Context) bool {
 	return c.IsDraftValue
+}
+
+func (c *MockPullContext) AutoMerge(ctx context.Context) bool {
+	return c.AutoMergeValue
 }
 
 // type assertion


### PR DESCRIPTION
This PR adds a new trigger type – `auto_merge`. GitHub REST API v3 exposes this status on the PR object, and it can be a pretty good indicator of merge readiness, a good alternative to `ready to merge` label for simple cases.

Please let me know if anything's amiss in my PR – this is me trying Go for the first time 😅 

Closes #289.

cc @bluekeyes