### PR TITLE
Fix error evaluating unprotected branches

### DIFF
--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -190,7 +190,7 @@ func (ghc *GithubContext) PushRestrictions(ctx context.Context) (bool, error) {
 func (ghc *GithubContext) loadBranchProtection(ctx context.Context) error {
 	protection, _, err := ghc.client.Repositories.GetBranchProtection(ctx, ghc.owner, ghc.repo, ghc.pr.GetBase().GetRef())
 	if err != nil {
-		if isNotFound(err) {
+		if isNotFound(err) || err == github.ErrBranchNotProtected {
 			ghc.branchProtection = &github.Protection{}
 			return nil
 		}


### PR DESCRIPTION
A change in go-github v42 (https://github.com/google/go-github/pull/2092) added a new error type when a branch is not protected instead of using the standard 404 error returned by GitHub. This meant our logic failed to detect that protection was missing and reported an error as if the API call failed.