### PR TITLE
Options can't be configured as ENV var

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ A sample configuration file is provided at `config/bulldozer.example.yml`.
 Certain values may also be set by environment variables; these are noted in the
 comments in the sample configuration file. By default, the environment
 variables for server values are prefixed with `BULLDOZER_` (e.g.
-`BULLDOZER_PORT`). This prefix can be overridden by setting the
+`BULLDOZER_PORT`). For configuring options the prefix is 
+`BULLDOZER_OPTIONS` (e.g. `BULLDOZER_OPTIONS_APP_NAME`)
+This prefix can be overridden by setting the
 `BULLDOZER_ENV_PREFIX` environment variable.
 
 ### GitHub App Configuration

--- a/config/bulldozer.example.yml
+++ b/config/bulldozer.example.yml
@@ -65,15 +65,31 @@ github:
 # Options for application behavior
 options:
   # The path within repositories to find the bulldozer.yml config file
+  # Can also be set by the BULLDOZER_OPTIONS_CONFIGURATION_PATH environment variable.
   configuration_path: .bulldozer.yml
 
   # The name of the application. This will affect the User-Agent header
   # when making requests to Github.
+  # Can also be set by the BULLDOZER_OPTIONS_APP_NAME environment variable.
   app_name: bulldozer
+
+#   # The name of an organization repository to look in for a shared bulldozer file if
+#   # a repository does not define a bulldozer file. Can also be set by the
+#   # BULLDOZER_OPTIONS_SHARED_REPOSITORY environment variable.
+#   shared_repository: .github
+
+#   # The path to the bulldozer file in the shared organization repository.
+#   # Can also be set by the BULLDOZER_OPTIONS_SHARED_CONFIGURATION_PATH environment variable.
+#   shared_policy_path: policy.yml
+
+#   # To reduce pressure on CI systems and Github, the update feature can be disabled at the
+#   # server level by specifying the following server option:
+#   # Can also be set by the BULLDOZER_OPTIONS_DISABLE_UPDATE_FEATURE environment variable.
+#   disable_update_feature: true
 
   # Deprecated: An optional personal access token associated with a GitHub user
   # that is used to merge pull requests into protected branches with push
-  # restrictions. Can also be set by the BULLDOZER_PUSH_RESTRICTION_USER_TOKEN
+  # restrictions. Can also be set by the BULLDOZER_OPTIONS_PUSH_RESTRICTION_USER_TOKEN
   # environment variable.
   #
   # This is not necessary on GitHub.com and GitHub Enterprise 2.20+, which

--- a/server/config.go
+++ b/server/config.go
@@ -68,9 +68,7 @@ func ParseConfig(bytes []byte) (*Config, error) {
 	}
 	c.Server.SetValuesFromEnv(envPrefix)
 
-	c.Options.SetValuesFromEnv("BULLDOZER_OPTIONS_")
-	// BULLDOZER_ENV_PREFIX_ will override the BULLDOZER_OPTIONS_ values.
-	c.Options.SetValuesFromEnv("BULLDOZER_ENV_PREFIX_")
+	c.Options.SetValuesFromEnv(envPrefix + "OPTIONS_")
 
 	return &c, nil
 }

--- a/server/config.go
+++ b/server/config.go
@@ -15,10 +15,10 @@
 package server
 
 import (
+	"github.com/palantir/bulldozer/server/handler"
 	"os"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/palantir/bulldozer/bulldozer"
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/palantir/go-baseapp/baseapp/datadog"
 	"github.com/palantir/go-githubapp/githubapp"
@@ -27,15 +27,13 @@ import (
 )
 
 const (
-	DefaultEnvPrefix               = "BULLDOZER_"
-	DefaultSharedRepository        = ".github"
-	DefaultSharedConfigurationPath = "bulldozer.yml"
+	DefaultEnvPrefix = "BULLDOZER_"
 )
 
 type Config struct {
 	Server  baseapp.HTTPConfig `yaml:"server"`
 	Github  githubapp.Config   `yaml:"github"`
-	Options Options            `yaml:"options"`
+	Options handler.Options    `yaml:"options"`
 	Logging LoggingConfig      `yaml:"logging"`
 	Datadog datadog.Config     `yaml:"datadog"`
 	Cache   CacheConfig        `yaml:"cache"`
@@ -56,20 +54,6 @@ type WorkerConfig struct {
 	QueueSize int `yaml:"queue_size"`
 }
 
-type Options struct {
-	AppName                  string `yaml:"app_name"`
-	PushRestrictionUserToken string `yaml:"push_restriction_user_token"`
-
-	ConfigurationPath       string            `yaml:"configuration_path"`
-	SharedRepository        string            `yaml:"shared_repository"`
-	SharedConfigurationPath string            `yaml:"shared_configuration_path"`
-	DefaultRepositoryConfig *bulldozer.Config `yaml:"default_repository_config"`
-
-	ConfigurationV0Paths []string `yaml:"configuration_v0_paths"`
-
-	DisableUpdateFeature bool `yaml:"disable_update_feature"`
-}
-
 func ParseConfig(bytes []byte) (*Config, error) {
 	var c Config
 	if err := yaml.UnmarshalStrict(bytes, &c); err != nil {
@@ -84,16 +68,9 @@ func ParseConfig(bytes []byte) (*Config, error) {
 	}
 	c.Server.SetValuesFromEnv(envPrefix)
 
-	if v, ok := os.LookupEnv(envPrefix + "PUSH_RESTRICTION_USER_TOKEN"); ok {
-		c.Options.PushRestrictionUserToken = v
-	}
-
-	if c.Options.SharedRepository == "" {
-		c.Options.SharedRepository = DefaultSharedRepository
-	}
-	if c.Options.SharedConfigurationPath == "" {
-		c.Options.SharedConfigurationPath = DefaultSharedConfigurationPath
-	}
+	c.Options.SetValuesFromEnv("BULLDOZER_OPTIONS_")
+	// BULLDOZER_ENV_PREFIX_ will override the BULLDOZER_OPTIONS_ values.
+	c.Options.SetValuesFromEnv("BULLDOZER_ENV_PREFIX_")
 
 	return &c, nil
 }

--- a/server/config.go
+++ b/server/config.go
@@ -15,10 +15,10 @@
 package server
 
 import (
-	"github.com/palantir/bulldozer/server/handler"
 	"os"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/palantir/bulldozer/server/handler"
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/palantir/go-baseapp/baseapp/datadog"
 	"github.com/palantir/go-githubapp/githubapp"

--- a/server/handler/options.go
+++ b/server/handler/options.go
@@ -15,9 +15,10 @@
 package handler
 
 import (
-	"github.com/palantir/bulldozer/bulldozer"
 	"os"
 	"strconv"
+
+	"github.com/palantir/bulldozer/bulldozer"
 )
 
 const (

--- a/server/handler/options.go
+++ b/server/handler/options.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"github.com/palantir/bulldozer/bulldozer"
+	"os"
+	"strconv"
+)
+
+const (
+	DefaultSharedRepository = ".github"
+	// DefaultConfigurationPath
+	// The default configuration path is the same for the repo as
+	// for the shared config if not configured
+	DefaultConfigurationPath = "bulldozer.yml"
+	DefaultAppName           = "bulldozer"
+)
+
+type Options struct {
+	AppName                  string `yaml:"app_name"`
+	PushRestrictionUserToken string `yaml:"push_restriction_user_token"`
+
+	ConfigurationPath       string            `yaml:"configuration_path"`
+	SharedRepository        string            `yaml:"shared_repository"`
+	SharedConfigurationPath string            `yaml:"shared_configuration_path"`
+	DefaultRepositoryConfig *bulldozer.Config `yaml:"default_repository_config"`
+
+	ConfigurationV0Paths []string `yaml:"configuration_v0_paths"`
+
+	DisableUpdateFeature bool `yaml:"disable_update_feature"`
+}
+
+func (o *Options) fillDefaults() {
+	if o.ConfigurationPath == "" {
+		o.ConfigurationPath = DefaultConfigurationPath
+	}
+	if o.AppName == "" {
+		o.AppName = DefaultAppName
+	}
+	if o.SharedRepository == "" {
+		o.SharedRepository = DefaultSharedRepository
+	}
+	if o.SharedConfigurationPath == "" {
+		o.SharedConfigurationPath = DefaultConfigurationPath
+	}
+}
+
+func (o *Options) SetValuesFromEnv(prefix string) {
+	setStringFromEnv("CONFIGURATION_PATH", prefix, &o.ConfigurationPath)
+	setStringFromEnv("APP_NAME", prefix, &o.AppName)
+	setStringFromEnv("SHARED_REPOSITORY", prefix, &o.SharedRepository)
+	setStringFromEnv("SHARED_CONFIGURATION_PATH", prefix, &o.SharedConfigurationPath)
+	setBooleanFromEnv("DISABLE_UPDATE_FEATURE", prefix, &o.DisableUpdateFeature)
+	setStringFromEnv("PUSH_RESTRICTION_USER_TOKEN", prefix, &o.PushRestrictionUserToken)
+	o.fillDefaults()
+}
+
+func setStringFromEnv(key, prefix string, value *string) bool {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		*value = v
+		return true
+	}
+	return false
+}
+
+func setBooleanFromEnv(key, prefix string, value *bool) bool {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		*value, _ = strconv.ParseBool(v)
+		return true
+	}
+	return false
+}

--- a/server/handler/options.go
+++ b/server/handler/options.go
@@ -21,12 +21,10 @@ import (
 )
 
 const (
-	DefaultSharedRepository = ".github"
-	// DefaultConfigurationPath
-	// The default configuration path is the same for the repo as
-	// for the shared config if not configured
-	DefaultConfigurationPath = "bulldozer.yml"
-	DefaultAppName           = "bulldozer"
+	DefaultSharedRepository        = ".github"
+	DefaultConfigurationPath       = ".bulldozer.yml"
+	DefaultSharedConfigurationPath = "bulldozer.yml"
+	DefaultAppName                 = "bulldozer"
 )
 
 type Options struct {
@@ -54,7 +52,7 @@ func (o *Options) fillDefaults() {
 		o.SharedRepository = DefaultSharedRepository
 	}
 	if o.SharedConfigurationPath == "" {
-		o.SharedConfigurationPath = DefaultConfigurationPath
+		o.SharedConfigurationPath = DefaultSharedConfigurationPath
 	}
 }
 


### PR DESCRIPTION
As mentioned in #358 this is the PR for that issue.

So to configure the options of Bulldozer we can use the following ENV vars:
| YAML name   | ENV name   |
|:-:|:-:|
| options.configuration_path  | BULLDOZER_OPTIONS_CONFIGURATION_PATH    |
| options,app_name   | BULLDOZER_OPTIONS_APP_NAME    |
| options,push_restriction_user_token| BULLDOZER_OPTIONS_PUSH_RESTRICTION_USER_TOKEN  |
| options,shared_repository| BULLDOZER_OPTIONS_SHARED_REPOSITORY  |
| options,shared_configuration_path| BULLDOZER_OPTIONS_SHARED_CONFIGURATION_PATH  |
| options,disable_update_feature | BULLDOZER_OPTIONS_DISABLE_UPDATE_FEATURE  |

And the possibility to override with `BULLDOZER_ENV_PREFIX_`.

So that means the following: 
`BULLDOZER_OPTIONS_` and also with `BULLDOZER_ENV_PREFIX_`.
The configured value with `BULLDOZER_ENV_PREFIX_`  will be the actual value then

