### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [develop]
     tags-ignore:
-      - '**'
+      - "**"
 
   pull_request:
     branches: [develop]
@@ -20,31 +20,31 @@ jobs:
       GOPATH: /home/runner/go
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Set Go version
-      id: go_version
-      run: |
-        GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
-        echo "::set-output name=version::${GO_VERSION}"
+      - name: Set Go version
+        id: go_version
+        run: |
+          GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
+          echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ steps.go_version.outputs.version }}
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.go_version.outputs.version }}
 
-    - name: Cache Godel assets
-      uses: actions/cache@v2
-      with:
-        path: ~/.godel
-        key: ${{ runner.os }}-godel-${{ hashFiles('godelw', 'godel/config/godel.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-godel-
+      - name: Cache Godel assets
+        uses: actions/cache@v2
+        with:
+          path: ~/.godel
+          key: ${{ runner.os }}-godel-${{ hashFiles('godelw', 'godel/config/godel.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-godel-
 
-    - name: Verify
-      run: ./godelw verify --apply=false
+      - name: Verify
+        run: ./godelw verify --apply=false
 
   Dist:
     runs-on: ubuntu-latest
@@ -57,62 +57,62 @@ jobs:
       GOPATH: /home/runner/go
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Set Go version
-      id: go_version
-      run: |
-        GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
-        echo "::set-output name=version::${GO_VERSION}"
+      - name: Set Go version
+        id: go_version
+        run: |
+          GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
+          echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ steps.go_version.outputs.version }}
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.go_version.outputs.version }}
 
-    - name: Cache Godel assets
-      uses: actions/cache@v2
-      with:
-        path: ~/.godel
-        key: ${{ runner.os }}-godel-${{ hashFiles('godelw', 'godel/config/godel.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-godel-
+      - name: Cache Godel assets
+        uses: actions/cache@v2
+        with:
+          path: ~/.godel
+          key: ${{ runner.os }}-godel-${{ hashFiles('godelw', 'godel/config/godel.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-godel-
 
-    - name: Build distribution
-      run: ./godelw dist
+      - name: Build distribution
+        run: ./godelw dist
 
-    - name: Build Docker image
-      run: ./godelw docker build --verbose
+      - name: Build Docker image
+        run: ./godelw docker build --verbose
 
-    - name: Archive distribution
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: |
-          build/bulldozer/*/bin/*.tgz
+      - name: Archive distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: |
+            build/bulldozer/*/bin/*.tgz
 
-    #
-    # Steps after this point should only run when publishing
-    # Include them here to avoid exporting the Docker container as an artifact
-    #
+      #
+      # Steps after this point should only run when publishing
+      # Include them here to avoid exporting the Docker container as an artifact
+      #
 
-    - name: Login to Docker Hub
-      if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to Docker Hub
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-    - name: Push snapshot image to Docker Hub
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      run: ./godelw docker push --tags=snapshot
+      - name: Push snapshot image to Docker Hub
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        run: ./godelw docker push --tags=snapshot
 
-    - name: Push release image to Docker Hub
-      if: ${{ github.event_name == 'release' }}
-      run: ./godelw docker push --tags=latest,version
+      - name: Push release image to Docker Hub
+        if: ${{ github.event_name == 'release' }}
+        run: ./godelw docker push --tags=latest,version
 
-    - name: Publish release assets
-      if: ${{ github.event_name == 'release' }}
-      run: ./godelw publish github --add-v-prefix --api-url=${GITHUB_API_URL} --user=palantir --repository=bulldozer --token=${{ secrets.GITHUB_TOKEN }}
+      - name: Publish release assets
+        if: ${{ github.event_name == 'release' }}
+        run: ./godelw publish github --add-v-prefix --api-url=${GITHUB_API_URL} --user=palantir --repository=bulldozer --token=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

