### PR TITLE
Remove usage of ::set-output in Actions workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,8 @@ jobs:
       id: go_version
       run: |
         GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
-        echo "::set-output name=version::${GO_VERSION}"
+        echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
This feature is deprecated in favor of the GITHUB_OUTPUT file.