### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         run: ./godelw docker build --verbose
 
       - name: Archive distribution
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: |


### PR DESCRIPTION
Apparently github has helpfully "deprecated" the old action, but it actually isn't deprecated its removed entirely. This breaks the build https://github.com/palantir/bulldozer/actions/runs/10902648483/job/30255011795