### PR TITLE
Make MaxPullRequestPollCount configurable via merge config

### DIFF
--- a/bulldozer/config_v1.go
+++ b/bulldozer/config_v1.go
@@ -53,6 +53,11 @@ type MergeConfig struct {
 	// Additional status checks that bulldozer should require
 	// (even if the branch protection settings doesn't require it)
 	RequiredStatuses []string `yaml:"required_statuses"`
+
+	// MaxPullRequestPollCount sets the maximum number of times bulldozer will
+	// poll for a pull request to become mergeable before giving up. If unset
+	// or zero, the default of 5 is used.
+	MaxPullRequestPollCount int `yaml:"max_pull_request_poll_count"`
 }
 
 type MergeOptions struct {

--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -28,7 +28,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const MaxPullRequestPollCount = 5
+const DefaultMaxPullRequestPollCount = 5
+
+// Deprecated: MaxPullRequestPollCount is retained for backward compatibility.
+// Use MergeConfig.MaxPullRequestPollCount or DefaultMaxPullRequestPollCount instead.
+const MaxPullRequestPollCount = DefaultMaxPullRequestPollCount
 
 type Merger interface {
 	// Merge merges the pull request in the context using the commit message
@@ -227,6 +231,11 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 		commitMsg.Title = title
 	}
 
+	maxAttempts := mergeConfig.MaxPullRequestPollCount
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultMaxPullRequestPollCount
+	}
+
 	var attempts int
 	var merged, retry bool
 	for {
@@ -236,7 +245,7 @@ func MergePR(ctx context.Context, pullCtx pull.Context, merger Merger, mergeConf
 		}
 
 		attempts++
-		if attempts >= MaxPullRequestPollCount {
+		if attempts >= maxAttempts {
 			logger.Error().Msgf("Failed to merge pull request after %d attempts", attempts)
 			return
 		}

--- a/changelog/@unreleased/pr-764.v2.yml
+++ b/changelog/@unreleased/pr-764.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: "Make MaxPullRequestPollCount configurable via `max_pull_request_poll_count` in server config"
+  links:
+    - href: https://github.com/palantir/bulldozer/pull/764
+      text: "764"

--- a/config/examples/standard.bulldozer.v1.yml
+++ b/config/examples/standard.bulldozer.v1.yml
@@ -13,3 +13,4 @@ merge:
       body: summarize_commits
   delete_after_merge: true
   allow_merge_with_no_checks: false
+  # max_pull_request_poll_count: 5  # Number of times to poll for mergeability before giving up (default: 5)


### PR DESCRIPTION
## Problem

The retry ceiling for poll-until-mergeable is hardcoded to 5 at compile time (`MaxPullRequestPollCount = 5` in `bulldozer/merge.go`). In organizations running large monorepos or slow CI systems, GitHub's mergeability check often takes longer than 5 × 4 s = 20 s to settle, causing bulldozer to give up and log an error even though the PR would have become mergeable moments later. There is no way to raise this limit without recompiling the server.

## Solution

Add an optional `max_pull_request_poll_count` field to `MergeConfig` (the per-repository `.bulldozer.yml` config). When the field is set to a positive integer, `MergePR` uses that value as the ceiling; when it is unset or zero, the previous default of 5 is used unchanged. This keeps the change fully backward-compatible.

The existing `MaxPullRequestPollCount` constant is retained (renamed to `DefaultMaxPullRequestPollCount`, with an alias for the old name) so any code that references it directly continues to compile.

## Changes

- `bulldozer/config_v1.go`: add `MaxPullRequestPollCount int` field to `MergeConfig`
- `bulldozer/merge.go`: rename constant, read effective limit from `mergeConfig.MaxPullRequestPollCount` at runtime
- `config/examples/standard.bulldozer.v1.yml`: document the new field in a comment

Fixes #666