### PR TITLE
Trigger release workflow on tag push instead of a release event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,11 @@ name: Build
 on:
   push:
     branches: [develop]
-    tags-ignore:
-      - "**"
+    tags:
+      - 'v[0-9]*'
 
   pull_request:
     branches: [develop]
-
-  release:
-    types: [published]
 
 jobs:
   Verify:
@@ -97,7 +94,7 @@ jobs:
       #
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+        if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -108,11 +105,11 @@ jobs:
         run: ./godelw docker push --tags=snapshot
 
       - name: Push release image to Docker Hub
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         run: ./godelw docker push --tags=latest,version
 
       - name: Publish release assets
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         run: ./godelw publish github --add-v-prefix --api-url=${GITHUB_API_URL} --user=palantir --repository=bulldozer --token=${{ secrets.GITHUB_TOKEN }}
 
   ci-all:

--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -2,3 +2,12 @@ version: 3
 options:
   disable_label_releases: true
   allow_patch_releases_on_major_series_branches: true
+  # Remove '[skip ci]' from Autorelease commit messages so the release tag push triggers the build workflow.
+  # GitHub Actions honors '[skip ci]' on the tagged commit.
+  disable_skip_ci: true
+
+# Create the GitHub release as a draft so the build workflow can upload the dist artifacts and then finalize
+# (un-draft) the release. GitHub's immutable-releases feature rejects asset uploads to a release once it has been
+# published.
+github_releases:
+  draft: true


### PR DESCRIPTION
## Before this PR
GitHub's immutable-releases feature rejects asset uploads to a release once it's published, so releases must be created as drafts, have artifacts uploaded, then get un-drafted.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Trigger release workflow on tag push instead of release event to support immutable releases
==COMMIT_MSG==

The workflow now triggers on push of a version tag and assets are published appropriately for snapshot/releases. Autorelease will now create a draft release, `./godelw publish github` will reuse the existing draft release to upload all assets, and will then finalize (un-draft) the release, making it immutable. The version of `godelw` was verified to support this new draft/upload/finalize workflow.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

