### PR TITLE
Add support for required status checks from GitHub rulesets

### DIFF
--- a/bulldozer/evaluate.go
+++ b/bulldozer/evaluate.go
@@ -132,6 +132,7 @@ func ShouldMergePR(ctx context.Context, pullCtx pull.Context, mergeConfig MergeC
 		return false, errors.Wrap(err, "failed to determine required Github status checks for merge")
 	}
 	requiredStatuses = append(requiredStatuses, mergeConfig.RequiredStatuses...)
+	logger.Debug().Msgf("%s has required status checks: [%s]", pullCtx.Locator(), strings.Join(requiredStatuses, ","))
 
 	if len(requiredStatuses) == 0 && !mergeConfig.AllowMergeWithNoChecks {
 		logger.Debug().Msgf("%s has 0 required status checks, but is deemed not mergeable because AllowMergeWithNoChecks is false", pullCtx.Locator())
@@ -142,6 +143,7 @@ func ShouldMergePR(ctx context.Context, pullCtx pull.Context, mergeConfig MergeC
 	if err != nil {
 		return false, errors.Wrap(err, "failed to determine currently successful status checks for merge")
 	}
+	logger.Debug().Msgf("%s has currently successful status checks: [%s]", pullCtx.Locator(), strings.Join(successStatuses, ","))
 
 	unsatisfiedStatuses := statusSetDifference(requiredStatuses, successStatuses)
 	if len(unsatisfiedStatuses) > 0 {

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -37,6 +37,7 @@ type GithubContext struct {
 	comments         []string
 	commits          []*Commit
 	branchProtection *github.Protection
+	branchRules      *github.BranchRules
 	successStatuses  []string
 }
 
@@ -169,10 +170,46 @@ func (ghc *GithubContext) RequiredStatuses(ctx context.Context) ([]string, error
 			return nil, err
 		}
 	}
-	if checks := ghc.branchProtection.GetRequiredStatusChecks(); checks != nil {
-		return checks.GetContexts(), nil
+	if ghc.branchRules == nil {
+		if err := ghc.loadBranchRules(ctx); err != nil {
+			return nil, err
+		}
 	}
-	return nil, nil
+	return ghc.requiredStatuses(), nil
+}
+
+func (ghc *GithubContext) requiredStatuses() []string {
+	seen := make(map[string]struct{})
+	var statuses []string
+
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		statuses = append(statuses, name)
+		seen[name] = struct{}{}
+	}
+
+	if ghc.branchProtection != nil {
+		if checks := ghc.branchProtection.GetRequiredStatusChecks(); checks != nil {
+			for _, name := range checks.GetContexts() {
+				add(name)
+			}
+		}
+	}
+
+	if ghc.branchRules != nil {
+		for _, rule := range ghc.branchRules.GetRequiredStatusChecks() {
+			for _, check := range rule.Parameters.RequiredStatusChecks {
+				add(check.Context)
+			}
+		}
+	}
+
+	return statuses
 }
 
 func (ghc *GithubContext) PushRestrictions(ctx context.Context) (bool, error) {
@@ -197,6 +234,16 @@ func (ghc *GithubContext) loadBranchProtection(ctx context.Context) error {
 		return errors.Wrapf(err, "cannot get branch protection for %s", ghc.Locator())
 	}
 	ghc.branchProtection = protection
+	return nil
+}
+
+func (ghc *GithubContext) loadBranchRules(ctx context.Context) error {
+	rules, _, err := ghc.client.Repositories.ListRulesForBranch(ctx, ghc.owner, ghc.repo, ghc.pr.GetBase().GetRef(), nil)
+	if err != nil {
+		return errors.Wrapf(err, "cannot get branch rules for %s", ghc.Locator())
+	}
+
+	ghc.branchRules = rules
 	return nil
 }
 

--- a/pull/github_context.go
+++ b/pull/github_context.go
@@ -203,7 +203,13 @@ func (ghc *GithubContext) requiredStatuses() []string {
 
 	if ghc.branchRules != nil {
 		for _, rule := range ghc.branchRules.GetRequiredStatusChecks() {
+			if rule == nil {
+				continue
+			}
 			for _, check := range rule.Parameters.RequiredStatusChecks {
+				if check == nil {
+					continue
+				}
 				add(check.Context)
 			}
 		}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Bulldozer only considered classic GitHub branch protection when determining required status checks. Repositories that use GitHub Rulesets instead of classic branch protection had their required status checks ignored, causing PRs to be incorrectly deemed not mergeable when `AllowMergeWithNoChecks` was false.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

- Combine required status checks from both classic branch protection and the new GitHub Rulesets
- Add `branchRules` to `GithubContext` to expose active branch rules
- Deduplicate required status check names when merging results from both sources
- Add few extra debug logs for status checks during `ShouldMergePR()`

==COMMIT_MSG==
Add support for required status checks from GitHub rulesets
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->