### PR TITLE
Bind the merge request to the commit that was evaluated

### DIFF
--- a/bulldozer/merge.go
+++ b/bulldozer/merge.go
@@ -90,9 +90,16 @@ func (m *GitHubMerger) ffOnlyMerge(ctx context.Context, pullCtx pull.Context) (s
 }
 
 func (m *GitHubMerger) defaultMerge(ctx context.Context, pullCtx pull.Context, method MergeMethod, msg CommitMessage) (string, error) {
+	// Bind the merge to the commit that was evaluated. Without this, GitHub
+	// merges whatever the head is when the request arrives, which may be a
+	// commit pushed after the merge conditions were checked. GitHub rejects a
+	// mismatch with 409, which attemptMerge treats as a non-retryable stop; the
+	// push that moved the head produces its own events, so the pull request is
+	// evaluated again against the new commit.
 	opts := github.PullRequestOptions{
 		CommitTitle: msg.Title,
 		MergeMethod: string(method),
+		SHA:         pullCtx.HeadSHA(),
 	}
 
 	result, _, err := m.client.PullRequests.Merge(ctx, pullCtx.Owner(), pullCtx.Repo(), pullCtx.Number(), msg.Message, &opts)

--- a/bulldozer/merge_test.go
+++ b/bulldozer/merge_test.go
@@ -17,9 +17,11 @@ package bulldozer
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-github/v90/github"
@@ -203,4 +205,36 @@ func TestBaseBranchChangedRetry(t *testing.T) {
 
 	_, retry := attemptMerge(ctx, pullCtx, merger, SquashAndMerge, CommitMessage{})
 	assert.True(t, retry, "should retry on base branch changed error")
+}
+
+func TestDefaultMergeBindsToEvaluatedHead(t *testing.T) {
+	const headSHA = "8dd53b0e5c0d0a1b6b3c9e2f4a7d8c1e0f9b2a3c"
+
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"merged": true, "sha": "deadbeef"}`))
+	}))
+	defer srv.Close()
+
+	client, err := github.NewClient(github.WithEnterpriseURLs(srv.URL, srv.URL))
+	require.NoError(t, err)
+
+	pullCtx := &pulltest.MockPullContext{
+		OwnerValue:   "testorg",
+		RepoValue:    "testrepo",
+		NumberValue:  1,
+		HeadSHAValue: headSHA,
+	}
+
+	merger := NewGitHubMerger(client)
+	_, err = merger.Merge(context.Background(), pullCtx, MergeCommit, CommitMessage{})
+	require.NoError(t, err)
+
+	assert.Equal(t, headSHA, body["sha"],
+		"the merge request must name the commit that was evaluated")
 }


### PR DESCRIPTION
## Before this PR

`ShouldMergePR` decides whether a pull request may merge using statuses fetched
for the head commit at evaluation time. `defaultMerge` then calls
`PullRequests.Merge` with the pull request **number** and no `sha`, so GitHub
merges whatever the head is when the request arrives.

If a commit is pushed between the check and the merge, the commit that lands is
not the commit that was checked. GitHub's own required status checks cover the
common case — the API refuses the merge, and `attemptMerge` already handles that
`405` — but they do not cover `required_statuses` from `bulldozer.yml`, which
GitHub does not know about. Those are precisely the contexts the option exists
for: *"additional status contexts that must pass before bulldozer can merge…
useful if you want to require extra testing for automated merges."*

`ffOnlyMerge` already binds to the evaluated commit: it passes
`SHA: headCommitSHA` to `UpdateRef` and verifies the ref moved to exactly that
commit. This change gives `defaultMerge` the same guarantee.

## After this PR

`defaultMerge` sets `SHA` on the existing `github.PullRequestOptions` from
`pullCtx.HeadSHA()` — the commit the merge conditions were evaluated against.
GitHub then merges that commit or refuses.

==COMMIT_MSG==
`defaultMerge` called `PullRequests.Merge` without a `sha`, so GitHub merged
whatever the head was when the request arrived rather than the commit whose
statuses were checked. This is invisible for GitHub-required contexts, which the
API enforces at merge time, but `required_statuses` from `bulldozer.yml` are
unknown to GitHub and unenforced by it.

Set `SHA` from `pullCtx.HeadSHA()`, matching what `ffOnlyMerge` already does.
==COMMIT_MSG==

## Possible downsides?

**A pull request whose head moves mid-merge now stops instead of merging.**
GitHub answers `409` on a `sha` mismatch, and `attemptMerge` treats `409` as a
non-retryable stop, so the merge does not happen on that attempt. This is the
intended behaviour change — the alternative is merging an unevaluated commit —
but it is a behaviour change and worth stating plainly.

**It should not leave pull requests stuck.** The push that moved the head produces
its own `pull_request` and status events, so the pull request is evaluated again
against the new commit and merged when it qualifies. Repositories that have seen
stuck-merge symptoms before (#187) may want to watch for this; if maintainers
would prefer the `409` to trigger an immediate re-evaluation rather than waiting
for the next event, I am happy to add that in this PR or a follow-up.

**The log line on that path currently reads** *"Merge rejected due to being
invalid"*, which is accurate but not obviously about a moved head. I left it
alone to keep the diff to the fix; happy to add a distinct message if you want it.

**Scope:** `ffOnlyMerge` is unchanged — it already binds to the evaluated commit
and verifies the result.

If the missing `sha` is deliberate, I'd rather hear the reasoning than have you
carry the PR — happy to close it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
